### PR TITLE
docs: (#1) Project-Bible 문서와 폴더 표준 정리

### DIFF
--- a/Document/cli/01_command-reference.md
+++ b/Document/cli/01_command-reference.md
@@ -14,7 +14,8 @@
 - `pb up`은 새 PowerShell 창을 열어 대상 서버를 실행한다.
 - `pb up`은 `--port`가 없으면 backend는 `8000`, frontend는 `3000`부터 자동 증가 포트를 할당한다.
 - backend Swagger 기본 경로는 `/docs`다.
-- `pb down`은 CLI 런타임 상태에 저장된 PID를 종료한다.
+- `pb down <target>`은 CLI 런타임 상태에 저장된 PID를 종료한다.
+- `pb down --port N`은 해당 포트의 CLI 추적 프로세스 또는 포트를 점유 중인 프로세스를 종료한다.
 - `pb db up`, `pb db down`, `pb db reset`은 Docker 기반 DB 명령으로 동작한다.
 
 ## 명령어 표
@@ -24,12 +25,16 @@
 | `pb list` | 없음 | 등록된 백엔드, 프론트, DB 타깃 목록을 출력한다. | `implemented` | 공용 | `pb list` |
 | `pb up <target> [--port N]` | `target`, `port` | 지정한 타깃을 새 PowerShell 창에서 기동한다. 포트를 주지 않으면 그룹 기준 자동 할당한다. | `implemented` | backend, frontend | `pb up post-java-springboot-maven-postgresql --port 9010` |
 | `pb down <target>` | `target` | CLI가 추적 중인 대상 프로세스를 종료한다. | `implemented` | backend, frontend | `pb down web-shop` |
+| `pb down --port N` | `port` | 지정한 포트를 점유 중인 CLI 추적 프로세스 또는 로컬 프로세스를 종료한다. | `implemented` | backend, frontend, local process | `pb down --port 3000` |
 | `pb test <target>` | `target` | 지정한 타깃의 테스트 명령을 현재 콘솔에서 실행한다. | `implemented` | backend, frontend | `pb test shop-typescript-nestjs-npm-postgresql` |
 | `pb db up` | 없음 | 공용 DB 인프라를 `docker compose up -d`로 기동한다. | `implemented` | database | `pb db up` |
 | `pb db down` | 없음 | 공용 DB 인프라를 `docker compose down`으로 종료한다. | `implemented` | database | `pb db down` |
 | `pb db reset <engine> <domain>` | `engine`, `domain` | 지정한 DB 엔진과 도메인 기준으로 DB를 drop/create 후 schema와 seed를 다시 적용한다. | `implemented` | database | `pb db reset postgresql post` |
 | `pb doctor` | 없음 | 로컬 실행 환경과 필수 도구 상태를 점검한다. | `implemented` | 공용 | `pb doctor` |
 | `pb gui` | 없음 | Tkinter 기반 로컬 GUI를 실행한다. | `implemented` | 공용 | `pb gui` |
+| `pb search <keyword>` | `keyword` | 명령어, 예시, 등록 타깃을 키워드로 검색한다. | `implemented` | 공용 | `pb search web` |
+| `pb --help`, `pb /?` | 없음 | 전체 명령 도움말을 출력한다. | `implemented` | 공용 | `pb /?` |
+| `pb <command> --help`, `pb <command> /?` | `command` | 특정 명령 도움말을 출력한다. | `implemented` | 공용 | `pb up /?` |
 
 ## 현재 구현 상태
 
@@ -37,12 +42,14 @@
 
 - `pb list`는 `projects.yaml`을 읽어 `backend`, `frontend`, `database` 그룹별 타깃을 출력한다.
 - `pb up`은 등록된 `start_command`를 새 PowerShell 창에서 실행하고 PID와 할당 포트를 기록한다.
-- `pb down`은 저장된 PID를 기준으로 대상 프로세스를 종료한다.
+- `pb down`은 저장된 PID 또는 지정 포트를 기준으로 대상 프로세스를 종료한다.
 - `pb test`는 등록된 `test_command`를 해당 프로젝트 경로에서 실행한다.
 - `pb db up`, `pb db down`은 `Database/docker/docker-compose.yml`을 기준으로 동작한다.
 - `pb db reset`은 엔진별 SQL 파일을 컨테이너 내부 DB에 다시 적용한다.
 - `pb doctor`는 Python, Node, npm, Java, Docker 존재 여부를 점검한다.
 - `pb gui`는 Tkinter GUI를 띄워 같은 기능을 호출한다.
+- `pb search`는 명령어와 등록 타깃 이름을 키워드로 검색한다.
+- `/?`는 `--help`와 같은 도움말 alias로 처리한다.
 
 ## 구성 메모
 
@@ -75,11 +82,14 @@
 ```text
 Started post-java-springboot-maven-postgresql in new PowerShell window (PID ..., port 8000)
 Stopped web-shop (PID ..., port 3001)
+Stopped untracked process using port 3000 (PID ...)
 ```
 
 ## 오류 및 주의사항
 
 - `target`이 `projects.yaml`에 없으면 명령은 실패한다.
 - 자동 포트는 CLI가 이미 추적 중인 프로세스와 현재 점유 중인 포트를 피해서 선택한다.
+- 사용자가 `--port`로 지정한 포트가 이미 열려 있으면 CLI는 점유 중인 CLI 타깃 또는 PID를 알려주고, `pb down <target>` 또는 `pb down --port N`으로 먼저 중지하라고 안내한다.
 - CLI 식별자와 실제 폴더명이 다르면 운영 규칙이 깨지므로 허용하지 않는다.
-- `pb down`은 `pb up`으로 기록된 PID가 없으면 종료할 대상을 찾지 못한다.
+- `pb down <target>`은 `pb up`으로 기록된 PID가 없으면 종료할 대상을 찾지 못한다.
+- `pb down --port N`은 CLI 상태에 없는 프로세스도 포트를 점유 중이면 `taskkill`로 종료할 수 있으므로 포트 번호를 확인하고 실행해야 한다.

--- a/Document/cli/03_runbook.md
+++ b/Document/cli/03_runbook.md
@@ -102,6 +102,10 @@ pb db reset postgresql post
 예시:
 
 ```powershell
+pb up web-post --port 3000
+pb down web-post
+pb up web-shop --port 3000
+pb down --port 3000
 pb test web-shop
 pb doctor
 ```
@@ -111,6 +115,29 @@ pb doctor
 - `pb test ...`: 대상 프로젝트의 테스트 스크립트 실행
 - `pb doctor`: Python, Node, npm, Java, Docker 경로 출력
 
+## 포트 충돌 처리 시나리오
+
+특정 포트로 실행:
+
+```powershell
+pb up web-post --port 3000
+```
+
+이미 포트가 열려 있으면 CLI는 점유 중인 CLI 타깃 또는 PID를 출력한다.
+이 경우 아래 중 하나로 먼저 종료한 뒤 다시 실행한다.
+
+```powershell
+pb down web-post
+pb down --port 3000
+pb up web-post --port 3000
+```
+
+주의:
+
+- `pb down <target>`은 CLI가 띄운 프로세스를 타깃명 기준으로 종료한다.
+- `pb down --port N`은 해당 포트를 점유 중인 프로세스를 기준으로 종료한다.
+- CLI가 띄우지 않은 프로세스도 종료할 수 있으므로 포트 번호를 확인하고 사용한다.
+
 ## 흔한 실수
 
 - `projects.yaml`의 `name`과 실제 폴더명을 다르게 적는 경우
@@ -119,6 +146,7 @@ pb doctor
 - 백엔드 이름에서 `springboot`, `nestjs`, `jpa`, `jdbc`, `typeorm`, `knex` 같은 고정 토큰을 임의로 변경하는 경우
 - `pb db reset` 전에 DB 컨테이너를 올리지 않는 경우
 - `pb down` 호출 전에 `pb up` 기록이 없는 경우
+- 이미 열려 있는 포트를 `pb up <target> --port N`으로 다시 지정하는 경우
 
 ## 운영 메모
 

--- a/Document/post/04_language.md
+++ b/Document/post/04_language.md
@@ -16,9 +16,6 @@
 - 빌드 도구:
   - Java: `Maven`, `Gradle`
   - TypeScript: `npm`
-- 데이터 접근:
-  - Java: `jdbc`, `jpa`
-  - TypeScript: `knex`, `typeorm`
 - DB 엔진: `postgresql`, `mysql`
 
 프로젝트 수 계산:
@@ -33,7 +30,8 @@
 
 실제 저장소 폴더명과 CLI 인자는 아래 규칙으로 통일한다.
 
-`<domain>-<language>-<framework>-<build>-<db>`
+- Java: `<domain>-java-springboot-<build>-<db>`
+- TypeScript: `<domain>-typescript-nestjs-npm-<db>`
 
 작성 규칙:
 
@@ -41,18 +39,15 @@
 - 구분자는 `-`만 사용한다.
 - 도메인은 맨 앞에 둔다.
 - 프레임워크 표기는 `springboot`, `nestjs`를 사용한다.
-- Java Raw SQL은 `jdbc`를 사용한다.
-- Java ORM은 `jpa`를 사용한다.
-- TypeScript Raw SQL은 `knex`를 사용한다.
-- TypeScript ORM은 `typeorm`을 사용한다.
+- TypeScript 프로젝트는 식별자에 `npm`을 포함한다.
 - DB 엔진은 `postgresql`, `mysql`을 사용한다.
 
 예시:
 
 - `post-java-springboot-maven-postgresql`
-- `post-java-springboot-gradle-jdbc-mysql`
+- `post-java-springboot-gradle-mysql`
 - `post-typescript-nestjs-npm-postgresql`
-- `post-typescript-nestjs-npm-knex-mysql`
+- `post-typescript-nestjs-npm-mysql`
 
 ## 백엔드 폴더 배치 규칙
 
@@ -63,9 +58,9 @@
 예시:
 
 - `Backend/post/post-java-springboot-maven-postgresql`
-- `Backend/post/post-java-springboot-gradle-jdbc-mysql`
+- `Backend/post/post-java-springboot-gradle-mysql`
 - `Backend/post/post-typescript-nestjs-npm-postgresql`
-- `Backend/post/post-typescript-nestjs-npm-knex-mysql`
+- `Backend/post/post-typescript-nestjs-npm-mysql`
 
 ## 언어별 생성 프로젝트 기준
 
@@ -109,13 +104,13 @@ CLI 식별 기준:
 예시 인자:
 
 - `post-java-springboot-maven-postgresql`
-- `post-typescript-nestjs-npm-knex-mysql`
+- `post-typescript-nestjs-npm-mysql`
 
 ## 결론
 
-이 문서 기준으로 `post` 서비스는 총 `12개`의 백엔드 구현 프로젝트를 가진다.
+이 문서 기준으로 `post` 서비스는 총 `6개`의 백엔드 구현 프로젝트를 가진다.
 
-- Java: `8개`
-- TypeScript: `4개`
+- Java: `4개`
+- TypeScript: `2개`
 
 공용 Python CLI는 `Tools/cli`에 `1개`만 두며, 실제 실행 대상은 위 폴더명 규칙을 따른 프로젝트명으로 선택한다.

--- a/Document/post/07_folder-java.md
+++ b/Document/post/07_folder-java.md
@@ -1,0 +1,103 @@
+# 07 Folder Java
+
+## 문서 목적
+
+이 문서는 `post` 서비스의 Java 백엔드에서 사용하는 권장 폴더 구조를 정리하는 기준 문서다.
+예시용 범용 MVC 트리가 아니라, 현재 `Project-Bible`의 대표 `post` Java 구현체와 요구사항/API 문서를 기준으로 정리한다.
+
+## 권장 폴더 트리
+
+```text
+project-root/
+├─ src/
+│  ├─ main/
+│  │  ├─ java/
+│  │  │  └─ com/projectbible/post/.../
+│  │  │     ├─ PostApplication.java
+│  │  │     │
+│  │  │     ├─ common/
+│  │  │     │  ├─ api/
+│  │  │     │  ├─ config/
+│  │  │     │  ├─ exception/
+│  │  │     │  ├─ presentation/
+│  │  │     │  └─ security/
+│  │  │     │
+│  │  │     ├─ auth/
+│  │  │     │  ├─ controller/
+│  │  │     │  ├─ service/
+│  │  │     │  ├─ dto/
+│  │  │     │  ├─ entity/
+│  │  │     │  └─ repository/
+│  │  │     │
+│  │  │     ├─ user/
+│  │  │     │  ├─ controller/
+│  │  │     │  ├─ service/
+│  │  │     │  ├─ dto/
+│  │  │     │  ├─ entity/
+│  │  │     │  └─ repository/
+│  │  │     │
+│  │  │     ├─ admin/
+│  │  │     │  ├─ controller/
+│  │  │     │  ├─ service/
+│  │  │     │  ├─ dto/
+│  │  │     │  ├─ entity/
+│  │  │     │  └─ repository/
+│  │  │     │
+│  │  │     ├─ board/
+│  │  │     │  ├─ controller/
+│  │  │     │  ├─ service/
+│  │  │     │  ├─ dto/
+│  │  │     │  ├─ entity/
+│  │  │     │  └─ repository/
+│  │  │     │
+│  │  │     ├─ post/
+│  │  │     │  ├─ controller/
+│  │  │     │  ├─ service/
+│  │  │     │  ├─ dto/
+│  │  │     │  ├─ entity/
+│  │  │     │  └─ repository/
+│  │  │     │
+│  │  │     ├─ comment/
+│  │  │     │  ├─ controller/
+│  │  │     │  ├─ service/
+│  │  │     │  ├─ dto/
+│  │  │     │  ├─ entity/
+│  │  │     │  └─ repository/
+│  │  │     │
+│  │  │     └─ like/
+│  │  │        ├─ controller/
+│  │  │        ├─ service/
+│  │  │        ├─ dto/
+│  │  │        ├─ entity/
+│  │  │        └─ repository/
+│  │  │
+│  │  └─ resources/
+│  │     ├─ application.yml
+│  │     └─ db/
+│  │        └─ migration/
+│  │
+│  └─ test/
+│     └─ java/
+│        └─ com/projectbible/post/.../
+│           ├─ common/
+│           ├─ auth/
+│           ├─ user/
+│           ├─ admin/
+│           ├─ board/
+│           ├─ post/
+│           ├─ comment/
+│           └─ like/
+│
+├─ pom.xml
+└─ README.md
+```
+
+## 구조 원칙
+
+- 공통 기능은 `common` 아래에 모은다.
+- 도메인 모듈은 `auth`, `user`, `admin`, `board`, `post`, `comment`, `like` 기준으로 나눈다.
+- 각 도메인 모듈은 `controller`, `service`, `dto`, `entity`, `repository` 5계층을 기본으로 사용한다.
+- `dto`는 요청과 응답에 사용하는 Java DTO를 함께 관리한다.
+- `board`는 게시판 관리, `post`는 게시글 CRUD, `comment`는 댓글, `like`는 좋아요 기능을 담당한다.
+- 관리자 대시보드와 운영 API는 `admin` 모듈 안에서 관리한다.
+- `resources`는 실행 설정과 DB 마이그레이션처럼 애플리케이션 운영에 필요한 파일만 둔다.

--- a/Document/post/07_folder-typescript.md
+++ b/Document/post/07_folder-typescript.md
@@ -1,0 +1,88 @@
+# 07 Folder TypeScript
+
+## 문서 목적
+
+이 문서는 `post` 서비스의 TypeScript 백엔드에서 사용하는 권장 폴더 구조를 정리하는 기준 문서다.
+예시용 Nest 템플릿 구조가 아니라, 현재 `Project-Bible`의 대표 `post` TypeScript 구현체와 요구사항/API 문서를 기준으로 정리한다.
+
+## 권장 폴더 트리
+
+```text
+project-root/
+├─ src/
+│  ├─ main.ts
+│  ├─ app.module.ts
+│  │
+│  ├─ common/
+│  │  └─ guards/
+│  │
+│  ├─ auth/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ users/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ admin/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ boards/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ posts/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ comments/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  └─ likes/
+│     ├─ controller/
+│     ├─ service/
+│     ├─ request/
+│     ├─ response/
+│     ├─ entity/
+│     └─ repository/
+│
+├─ test/
+├─ package.json
+└─ README.md
+```
+
+## 구조 원칙
+
+- 공통 기능은 `common` 아래에 모은다.
+- 도메인 모듈은 `auth`, `users`, `admin`, `boards`, `posts`, `comments`, `likes` 기준으로 나눈다.
+- 각 도메인 모듈은 `controller`, `service`, `request`, `response`, `entity`, `repository` 6계층을 기본으로 사용한다.
+- `request`는 입력 DTO, `response`는 출력 DTO를 분리해서 관리한다.
+- `boards`는 게시판 관리, `posts`는 게시글 CRUD, `comments`는 댓글, `likes`는 좋아요 기능을 담당한다.
+- 관리자 대시보드와 운영 API는 `admin` 모듈 안에서 관리한다.
+- `main.ts`, `app.module.ts`는 애플리케이션 엔트리로 루트에 둔다.

--- a/Document/shop/04_language.md
+++ b/Document/shop/04_language.md
@@ -16,9 +16,6 @@
 - 빌드 도구:
   - Java: `Maven`, `Gradle`
   - TypeScript: `npm`
-- 데이터 접근:
-  - Java: `jdbc`, `jpa`
-  - TypeScript: `knex`, `typeorm`
 - DB 엔진: `postgresql`, `mysql`
 
 프로젝트 수 계산:
@@ -27,13 +24,14 @@
 | --- | --- | --- |
 | Java | `2 build tools x 2 db` | `4개` |
 | TypeScript | `1 build tool x 2 db` | `2개` |
-| 합계 | `8 + 4` | `12개` |
+| 합계 | `4 + 2` | `6개` |
 
 ## 폴더명 규칙
 
 실제 저장소 폴더명과 CLI 인자는 아래 규칙으로 통일한다.
 
-`<domain>-<language>-<framework>-<build>-<db>`
+- Java: `<domain>-java-springboot-<build>-<db>`
+- TypeScript: `<domain>-typescript-nestjs-npm-<db>`
 
 작성 규칙:
 
@@ -41,18 +39,15 @@
 - 구분자는 `-`만 사용한다.
 - 도메인은 맨 앞에 둔다.
 - 프레임워크 표기는 `springboot`, `nestjs`를 사용한다.
-- Java Raw SQL은 `jdbc`를 사용한다.
-- Java ORM은 `jpa`를 사용한다.
-- TypeScript Raw SQL은 `knex`를 사용한다.
-- TypeScript ORM은 `typeorm`을 사용한다.
+- TypeScript 프로젝트는 식별자에 `npm`을 포함한다.
 - DB 엔진은 `postgresql`, `mysql`을 사용한다.
 
 예시:
 
 - `shop-java-springboot-maven-postgresql`
 - `shop-java-springboot-gradle-mysql`
-- `shop-typescript-nestjs-typeorm-postgresql`
-- `shop-typescript-nestjs-knex-mysql`
+- `shop-typescript-nestjs-npm-postgresql`
+- `shop-typescript-nestjs-npm-mysql`
 
 ## 백엔드 폴더 배치 규칙
 
@@ -113,9 +108,9 @@ CLI 식별 기준:
 
 ## 결론
 
-이 문서 기준으로 `shop` 서비스는 총 `12개`의 백엔드 구현 프로젝트를 가진다.
+이 문서 기준으로 `shop` 서비스는 총 `6개`의 백엔드 구현 프로젝트를 가진다.
 
-- Java: `8개`
-- TypeScript: `4개`
+- Java: `4개`
+- TypeScript: `2개`
 
 공용 Python CLI는 `Tools/cli`에 `1개`만 두며, 실제 실행 대상은 위 폴더명 규칙을 따른 프로젝트명으로 선택한다.

--- a/Document/shop/07_folder-java.md
+++ b/Document/shop/07_folder-java.md
@@ -1,0 +1,80 @@
+# 07 Folder Java
+
+## 문서 목적
+
+이 문서는 `shop` 서비스의 Java 백엔드에서 사용하는 권장 폴더 구조를 정리하는 기준 문서다.
+예시용 범용 MVC 트리가 아니라, 현재 `Project-Bible`의 대표 `shop` Java 구현체와 요구사항/API 문서를 기준으로 정리한다.
+
+## 권장 폴더 트리
+
+```text
+project-root/
+├─ src/
+│  ├─ main/
+│  │  ├─ java/
+│  │  │  └─ com/projectbible/shop/.../
+│  │  │     ├─ ShopApplication.java
+│  │  │     │
+│  │  │     ├─ common/
+│  │  │     │  ├─ api/
+│  │  │     │  ├─ config/
+│  │  │     │  ├─ exception/
+│  │  │     │  ├─ presentation/
+│  │  │     │  └─ security/
+│  │  │     │
+│  │  │     ├─ auth/
+│  │  │     ├─ user/
+│  │  │     ├─ admin/
+│  │  │     ├─ category/
+│  │  │     ├─ product/
+│  │  │     ├─ cart/
+│  │  │     ├─ address/
+│  │  │     ├─ order/
+│  │  │     ├─ payment/
+│  │  │     └─ review/
+│  │  │
+│  │  └─ resources/
+│  │     ├─ application.yml
+│  │     └─ db/
+│  │        └─ migration/
+│  │
+│  └─ test/
+│     └─ java/
+│        └─ com/projectbible/shop/.../
+│           ├─ common/
+│           ├─ auth/
+│           ├─ user/
+│           ├─ admin/
+│           ├─ category/
+│           ├─ product/
+│           ├─ cart/
+│           ├─ address/
+│           ├─ order/
+│           ├─ payment/
+│           └─ review/
+│
+├─ pom.xml
+└─ README.md
+```
+
+각 도메인 모듈의 기본 하위 구조:
+
+```text
+<module>/
+├─ controller/
+├─ service/
+├─ dto/
+├─ entity/
+└─ repository/
+```
+
+## 구조 원칙
+
+- 공통 기능은 `common` 아래에 모은다.
+- 도메인 모듈은 `auth`, `user`, `admin`, `category`, `product`, `cart`, `address`, `order`, `payment`, `review` 기준으로 나눈다.
+- 각 도메인 모듈은 `controller`, `service`, `dto`, `entity`, `repository` 5계층을 기본으로 사용한다.
+- `dto`는 요청과 응답에 사용하는 Java DTO를 함께 관리한다.
+- `product` 모듈 안에서 상품 기본 정보와 옵션, 이미지 관리를 함께 처리한다.
+- `order` 모듈 안에서 주문 본문, 주문 상품 라인, 주문 배송지 스냅샷 구조를 함께 관리한다.
+- 관리자 대시보드와 운영 API는 `admin` 모듈 안에서 관리한다.
+- `resources`는 실행 설정과 DB 마이그레이션처럼 애플리케이션 운영에 필요한 파일만 둔다.

--- a/Document/shop/07_folder-typescript.md
+++ b/Document/shop/07_folder-typescript.md
@@ -1,0 +1,113 @@
+# 07 Folder TypeScript
+
+## 문서 목적
+
+이 문서는 `shop` 서비스의 TypeScript 백엔드에서 사용하는 권장 폴더 구조를 정리하는 기준 문서다.
+예시용 Nest 템플릿 구조가 아니라, 현재 `Project-Bible`의 대표 `shop` TypeScript 구현체와 요구사항/API 문서를 기준으로 정리한다.
+
+## 권장 폴더 트리
+
+```text
+project-root/
+├─ src/
+│  ├─ main.ts
+│  ├─ app.module.ts
+│  │
+│  ├─ common/
+│  │  └─ guards/
+│  │
+│  ├─ auth/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ users/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ admin/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ categories/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ products/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ cart/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ addresses/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ orders/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  ├─ payments/
+│  │  ├─ controller/
+│  │  ├─ service/
+│  │  ├─ request/
+│  │  ├─ response/
+│  │  ├─ entity/
+│  │  └─ repository/
+│  │
+│  └─ reviews/
+│     ├─ controller/
+│     ├─ service/
+│     ├─ request/
+│     ├─ response/
+│     ├─ entity/
+│     └─ repository/
+│
+├─ test/
+├─ package.json
+└─ README.md
+```
+
+## 구조 원칙
+
+- 공통 기능은 `common` 아래에 모은다.
+- 도메인 모듈은 `auth`, `users`, `admin`, `categories`, `products`, `cart`, `addresses`, `orders`, `payments`, `reviews` 기준으로 나눈다.
+- 각 도메인 모듈은 `controller`, `service`, `request`, `response`, `entity`, `repository` 6계층을 기본으로 사용한다.
+- `request`는 입력 DTO, `response`는 출력 DTO를 분리해서 관리한다.
+- `products` 모듈 안에서 상품 기본 정보와 옵션, 이미지 관리를 함께 처리한다.
+- `orders` 모듈 안에서 주문 본문, 주문 상품 라인, 주문 배송지 스냅샷 구조를 함께 관리한다.
+- 관리자 대시보드와 운영 API는 `admin` 모듈 안에서 관리한다.
+- `main.ts`, `app.module.ts`는 애플리케이션 엔트리로 루트에 둔다.


### PR DESCRIPTION
## Summary
Project-Bible 전체 문서 체계를 현재 실제 저장소 구조 기준으로 재정렬합니다.

## Scope
- `Document/post`, `Document/shop` 요구사항/ERD/API 명세 정리
- `04_language.md`를 실제 6개 구현체 기준으로 보정
- `07_folder-java.md`, `07_folder-typescript.md`를 현재 표준 폴더 구조 기준으로 정리
- `Document/cli` 문서 세트 추가
- 테스트/CI 문서를 현재 12개 백엔드 구조 기준으로 보정

## Result
- 문서가 예전 `jdbc/knex/typeorm` 매트릭스가 아니라 현재 `maven/gradle/mysql/postgresql` + `nestjs npm` 구조를 기준으로 설명합니다.
- `post`와 `shop` 문서가 동일한 형식을 유지하면서 도메인 차이만 반영합니다.
- CLI, 폴더 구조, 테스트, CI 문서가 실제 코드 구조와 충돌하지 않도록 맞췄습니다.

## Validation
- 문서 예시 폴더명이 실제 `Backend/post`, `Backend/shop` 폴더명과 일치하는지 점검
- CLI 예시 타깃명이 `projects.yaml` 기준 식별자와 일치하는지 점검
- `post/shop 07_folder-*` 문서가 현재 Java/Nest 표준 구조와 충돌하지 않는지 점검

## Notes
- 이 PR은 기준 문서를 먼저 고정하는 단계입니다.
- 이후 DB, backend, CLI, frontend, CI PR이 이 문서 기준을 따릅니다.

Closes #1