### PR TITLE
chore: (#2) 공용 Database 스키마와 시드 정리

### DIFF
--- a/Database/mysql/post/seeds/01_seed.sql
+++ b/Database/mysql/post/seeds/01_seed.sql
@@ -1,26 +1,26 @@
 INSERT INTO admins (id, email, password_hash, name, status) VALUES
-  (1, 'admin-post-1@example.com', 'hashed-admin-1', 'Post Admin 1', 'ACTIVE'),
-  (2, 'admin-post-2@example.com', 'hashed-admin-2', 'Post Admin 2', 'ACTIVE');
+  (1, 'admin-post-1@example.com', '$2a$10$14w0lOj3Jm7WF2ZXQ6qvGuYqHaJu7.R3CB/ZOwznKOS77jUSSOvca', 'Post Admin 1', 'ACTIVE'),
+  (2, 'admin-post-2@example.com', '$2a$10$14w0lOj3Jm7WF2ZXQ6qvGuYqHaJu7.R3CB/ZOwznKOS77jUSSOvca', 'Post Admin 2', 'ACTIVE');
 
 INSERT INTO users (id, email, password_hash, nickname, status) VALUES
-  (1, 'post-user-1@example.com', 'hashed-user-1', 'writer-one', 'ACTIVE'),
-  (2, 'post-user-2@example.com', 'hashed-user-2', 'writer-two', 'ACTIVE'),
-  (3, 'post-user-3@example.com', 'hashed-user-3', 'reader-three', 'ACTIVE');
+  (1, 'post-user-1@example.com', '$2a$10$oxn/00RSwIT5Opg4SLhpG.p9huJkLMthMGsre/vlkx5GpOT.hy/oe', 'writer-one', 'ACTIVE'),
+  (2, 'post-user-2@example.com', '$2a$10$oxn/00RSwIT5Opg4SLhpG.p9huJkLMthMGsre/vlkx5GpOT.hy/oe', 'writer-two', 'ACTIVE'),
+  (3, 'post-user-3@example.com', '$2a$10$oxn/00RSwIT5Opg4SLhpG.p9huJkLMthMGsre/vlkx5GpOT.hy/oe', 'reader-three', 'ACTIVE');
 
 INSERT INTO boards (id, created_by_admin_id, name, description, display_order, status) VALUES
-  (1, 1, 'free', '자유 게시판', 1, 'ACTIVE'),
-  (2, 1, 'qna', '질문 게시판', 2, 'ACTIVE'),
-  (3, 2, 'notice-like', '운영 참고 게시판', 3, 'HIDDEN');
+  (1, 1, 'free', 'Free board', 1, 'ACTIVE'),
+  (2, 1, 'qna', 'Question board', 2, 'ACTIVE'),
+  (3, 2, 'notice-like', 'Operation sample board', 3, 'HIDDEN');
 
 INSERT INTO posts (id, board_id, user_id, title, content, view_count, like_count, comment_count, status) VALUES
-  (1, 1, 1, '첫 번째 자유글', '자유 게시판 샘플 본문입니다.', 12, 2, 2, 'ACTIVE'),
-  (2, 2, 2, '질문 있습니다', 'ERD 기준 댓글과 좋아요가 연결됩니다.', 7, 1, 1, 'ACTIVE'),
-  (3, 1, 2, '숨김 처리 대상 예시', '관리자 운영 상태 샘플입니다.', 3, 0, 0, 'HIDDEN');
+  (1, 1, 1, 'First free post', 'Sample content for free board.', 12, 2, 2, 'ACTIVE'),
+  (2, 2, 2, 'Question post', 'Sample content linked with comments and likes.', 7, 1, 1, 'ACTIVE'),
+  (3, 1, 2, 'Hidden sample post', 'Sample content for moderation.', 3, 0, 0, 'HIDDEN');
 
 INSERT INTO comments (id, post_id, user_id, content, status) VALUES
-  (1, 1, 2, '첫 댓글입니다.', 'ACTIVE'),
-  (2, 1, 3, '두 번째 댓글입니다.', 'ACTIVE'),
-  (3, 2, 1, '질문에 대한 답변 예시입니다.', 'ACTIVE');
+  (1, 1, 2, 'First comment.', 'ACTIVE'),
+  (2, 1, 3, 'Second comment.', 'ACTIVE'),
+  (3, 2, 1, 'Sample answer comment.', 'ACTIVE');
 
 INSERT INTO post_likes (id, post_id, user_id) VALUES
   (1, 1, 2),

--- a/Database/mysql/shop/seeds/01_seed.sql
+++ b/Database/mysql/shop/seeds/01_seed.sql
@@ -1,10 +1,10 @@
 INSERT INTO admins (id, email, password_hash, name, status) VALUES
-  (1, 'admin-shop-1@example.com', 'hashed-shop-admin', 'Shop Admin', 'ACTIVE');
+  (1, 'admin-shop-1@example.com', '$2a$10$14w0lOj3Jm7WF2ZXQ6qvGuYqHaJu7.R3CB/ZOwznKOS77jUSSOvca', 'Shop Admin', 'ACTIVE');
 
 INSERT INTO users (id, email, password_hash, name, phone, status) VALUES
-  (1, 'shop-user-1@example.com', 'hashed-shop-user-1', 'Alice Kim', '010-1111-1111', 'ACTIVE'),
-  (2, 'shop-user-2@example.com', 'hashed-shop-user-2', 'Bob Lee', '010-2222-2222', 'ACTIVE'),
-  (3, 'shop-user-3@example.com', 'hashed-shop-user-3', 'Chris Park', '010-3333-3333', 'ACTIVE');
+  (1, 'shop-user-1@example.com', '$2a$10$oxn/00RSwIT5Opg4SLhpG.p9huJkLMthMGsre/vlkx5GpOT.hy/oe', 'Alice Kim', '010-1111-1111', 'ACTIVE'),
+  (2, 'shop-user-2@example.com', '$2a$10$oxn/00RSwIT5Opg4SLhpG.p9huJkLMthMGsre/vlkx5GpOT.hy/oe', 'Bob Lee', '010-2222-2222', 'ACTIVE'),
+  (3, 'shop-user-3@example.com', '$2a$10$oxn/00RSwIT5Opg4SLhpG.p9huJkLMthMGsre/vlkx5GpOT.hy/oe', 'Chris Park', '010-3333-3333', 'ACTIVE');
 
 INSERT INTO categories (id, name, display_order, status) VALUES
   (1, 'keyboard', 1, 'ACTIVE'),
@@ -12,10 +12,10 @@ INSERT INTO categories (id, name, display_order, status) VALUES
   (3, 'monitor', 3, 'ACTIVE');
 
 INSERT INTO products (id, category_id, name, description, price, stock, status) VALUES
-  (1, 1, 'PB Mechanical Keyboard', '기계식 키보드 샘플 상품', 129000.00, 50, 'ACTIVE'),
-  (2, 2, 'PB Wireless Mouse', '무선 마우스 샘플 상품', 59000.00, 80, 'ACTIVE'),
-  (3, 3, 'PB 27 Monitor', '27인치 모니터 샘플 상품', 329000.00, 20, 'ACTIVE'),
-  (4, 1, 'PB Compact Keyboard', '컴팩트 키보드 샘플 상품', 99000.00, 35, 'HIDDEN');
+  (1, 1, 'PB Mechanical Keyboard', 'Mechanical keyboard sample product', 129000.00, 50, 'ACTIVE'),
+  (2, 2, 'PB Wireless Mouse', 'Wireless mouse sample product', 59000.00, 80, 'ACTIVE'),
+  (3, 3, 'PB 27 Monitor', '27 inch monitor sample product', 329000.00, 20, 'ACTIVE'),
+  (4, 1, 'PB Compact Keyboard', 'Compact keyboard sample product', 99000.00, 35, 'HIDDEN');
 
 INSERT INTO product_options (id, product_id, name, value, additional_price, stock) VALUES
   (1, 1, 'switch', 'red', 0.00, 20),
@@ -56,4 +56,4 @@ INSERT INTO payments (id, order_id, payment_method, payment_status, paid_amount,
   (2, 2, 'mock-card', 'PAID', 329000.00, CURRENT_TIMESTAMP);
 
 INSERT INTO reviews (id, order_item_id, product_id, user_id, rating, content, status) VALUES
-  (1, 2, 3, 2, 5, '모니터 품질이 좋아요.', 'ACTIVE');
+  (1, 2, 3, 2, 5, 'Monitor quality is good.', 'ACTIVE');

--- a/Database/postgresql/post/seeds/01_seed.sql
+++ b/Database/postgresql/post/seeds/01_seed.sql
@@ -8,19 +8,19 @@ INSERT INTO users (id, email, password_hash, nickname, status) VALUES
   (3, 'post-user-3@example.com', '$2a$10$oxn/00RSwIT5Opg4SLhpG.p9huJkLMthMGsre/vlkx5GpOT.hy/oe', 'reader-three', 'ACTIVE');
 
 INSERT INTO boards (id, created_by_admin_id, name, description, display_order, status) VALUES
-  (1, 1, 'free', '자유 게시판', 1, 'ACTIVE'),
-  (2, 1, 'qna', '질문 게시판', 2, 'ACTIVE'),
-  (3, 2, 'notice-like', '운영 참고 게시판', 3, 'HIDDEN');
+  (1, 1, 'free', 'Free board', 1, 'ACTIVE'),
+  (2, 1, 'qna', 'Question board', 2, 'ACTIVE'),
+  (3, 2, 'notice-like', 'Operation sample board', 3, 'HIDDEN');
 
 INSERT INTO posts (id, board_id, user_id, title, content, view_count, like_count, comment_count, status) VALUES
-  (1, 1, 1, '첫 번째 자유글', '자유 게시판 샘플 본문입니다.', 12, 2, 2, 'ACTIVE'),
-  (2, 2, 2, '질문 있습니다', 'ERD 기준 댓글과 좋아요가 연결됩니다.', 7, 1, 1, 'ACTIVE'),
-  (3, 1, 2, '숨김 처리 대상 예시', '관리자 운영 상태 샘플입니다.', 3, 0, 0, 'HIDDEN');
+  (1, 1, 1, 'First free post', 'Sample content for free board.', 12, 2, 2, 'ACTIVE'),
+  (2, 2, 2, 'Question post', 'Sample content linked with comments and likes.', 7, 1, 1, 'ACTIVE'),
+  (3, 1, 2, 'Hidden sample post', 'Sample content for moderation.', 3, 0, 0, 'HIDDEN');
 
 INSERT INTO comments (id, post_id, user_id, content, status) VALUES
-  (1, 1, 2, '첫 댓글입니다.', 'ACTIVE'),
-  (2, 1, 3, '두 번째 댓글입니다.', 'ACTIVE'),
-  (3, 2, 1, '질문에 대한 답변 예시입니다.', 'ACTIVE');
+  (1, 1, 2, 'First comment.', 'ACTIVE'),
+  (2, 1, 3, 'Second comment.', 'ACTIVE'),
+  (3, 2, 1, 'Sample answer comment.', 'ACTIVE');
 
 INSERT INTO post_likes (id, post_id, user_id) VALUES
   (1, 1, 2),

--- a/Database/postgresql/shop/seeds/01_seed.sql
+++ b/Database/postgresql/shop/seeds/01_seed.sql
@@ -12,10 +12,10 @@ INSERT INTO categories (id, name, display_order, status) VALUES
   (3, 'monitor', 3, 'ACTIVE');
 
 INSERT INTO products (id, category_id, name, description, price, stock, status) VALUES
-  (1, 1, 'PB Mechanical Keyboard', '기계식 키보드 샘플 상품', 129000.00, 50, 'ACTIVE'),
-  (2, 2, 'PB Wireless Mouse', '무선 마우스 샘플 상품', 59000.00, 80, 'ACTIVE'),
-  (3, 3, 'PB 27 Monitor', '27인치 모니터 샘플 상품', 329000.00, 20, 'ACTIVE'),
-  (4, 1, 'PB Compact Keyboard', '컴팩트 키보드 샘플 상품', 99000.00, 35, 'HIDDEN');
+  (1, 1, 'PB Mechanical Keyboard', 'Mechanical keyboard sample product', 129000.00, 50, 'ACTIVE'),
+  (2, 2, 'PB Wireless Mouse', 'Wireless mouse sample product', 59000.00, 80, 'ACTIVE'),
+  (3, 3, 'PB 27 Monitor', '27 inch monitor sample product', 329000.00, 20, 'ACTIVE'),
+  (4, 1, 'PB Compact Keyboard', 'Compact keyboard sample product', 99000.00, 35, 'HIDDEN');
 
 INSERT INTO product_options (id, product_id, name, value, additional_price, stock) VALUES
   (1, 1, 'switch', 'red', 0.00, 20),
@@ -56,7 +56,7 @@ INSERT INTO payments (id, order_id, payment_method, payment_status, paid_amount,
   (2, 2, 'mock-card', 'PAID', 329000.00, CURRENT_TIMESTAMP);
 
 INSERT INTO reviews (id, order_item_id, product_id, user_id, rating, content, status) VALUES
-  (1, 2, 3, 2, 5, '모니터 품질이 좋아요.', 'ACTIVE');
+  (1, 2, 3, 2, 5, 'Monitor quality is good.', 'ACTIVE');
 
 SELECT setval(pg_get_serial_sequence('admins', 'id'), COALESCE((SELECT MAX(id) FROM admins), 1), true);
 SELECT setval(pg_get_serial_sequence('users', 'id'), COALESCE((SELECT MAX(id) FROM users), 1), true);


### PR DESCRIPTION
## Summary
공용 `Database` 구조를 `postgresql/mysql x post/shop` 기준으로 정리하고, 각 도메인의 schema/seed를 추가합니다.

## Scope
- `Database/postgresql/post|shop/init`
- `Database/postgresql/post|shop/seeds`
- `Database/mysql/post|shop/init`
- `Database/mysql/post|shop/seeds`
- `Database/docker` 기준 정리

## Result
- `post`는 `users`, `admins`, `refresh_tokens`, `boards`, `posts`, `comments`, `post_likes` 스키마를 가집니다.
- `shop`은 `categories`, `products`, `product_options`, `product_images`, `cart_items`, `addresses`, `orders`, `order_addresses`, `order_items`, `payments`, `reviews`까지 포함합니다.
- PostgreSQL/MySQL 두 엔진 모두 동일한 의미의 테이블과 샘플 데이터를 제공합니다.

## Validation
- seed 계정 기준 로그인 가능 데이터 포함 여부 점검
- `pb_post`, `pb_shop` 기준 schema/seed 적용 가능 여부 점검
- 백엔드 대표 구현체가 현재 schema/seed와 맞물려 동작하는지 확인

## Notes
- refresh token은 앱 실행 중 생성되는 데이터라 seed 필수 대상에서 제외했습니다.
- 이 PR 이후 backend PR들이 동일 schema/seed를 공통 기준으로 사용합니다.

Closes #2