### PR TITLE
feature: (#6) post/shop 프론트엔드 FSD 5계층 구현

### DIFF
--- a/Frontend/web-post/e2e/navigation.spec.ts
+++ b/Frontend/web-post/e2e/navigation.spec.ts
@@ -1,0 +1,73 @@
+import { expect, test } from "@playwright/test";
+
+const envelope = (data: unknown, meta?: unknown) => ({
+  success: true,
+  data,
+  ...(meta ? { meta } : {}),
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+
+    if (path === "/api/v1/health") {
+      await route.fulfill({ json: envelope({ status: "UP", service: "web-post-smoke" }) });
+      return;
+    }
+    if (path === "/api/v1/boards") {
+      await route.fulfill({ json: envelope([{ id: 1, name: "notice", description: "Notice", displayOrder: 1, status: "ACTIVE" }]) });
+      return;
+    }
+    if (path.startsWith("/api/v1/posts") || path.startsWith("/api/v1/admin/posts")) {
+      await route.fulfill({
+        json: envelope(
+          [{ id: 1, boardId: 1, title: "Smoke post", viewCount: 1, likeCount: 0, commentCount: 0, status: "ACTIVE" }],
+          { page: 1, limit: 20, totalCount: 1, totalPages: 1 },
+        ),
+      });
+      return;
+    }
+    if (path.startsWith("/api/v1/admin/comments")) {
+      await route.fulfill({
+        json: envelope(
+          [{ id: 1, postId: 1, content: "Smoke comment", status: "ACTIVE" }],
+          { page: 1, limit: 20, totalCount: 1, totalPages: 1 },
+        ),
+      });
+      return;
+    }
+    if (path === "/api/v1/admin/dashboard") {
+      await route.fulfill({ json: envelope({ boardCount: 1, postCount: 1, commentCount: 1, moderationTargetCount: 0 }) });
+      return;
+    }
+    if (path.includes("/auth/login")) {
+      await route.fulfill({ json: envelope({ accessToken: "access-token", refreshToken: "refresh-token" }) });
+      return;
+    }
+
+    await route.fulfill({ json: envelope({ message: "ok" }) });
+  });
+});
+
+test("navigates core post screens", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("h1")).toHaveText("Post Home");
+
+  const screens = [
+    ["Login", "Login"],
+    ["Signup", "Signup"],
+    ["Boards", "Boards"],
+    ["Post Detail", "Post Detail"],
+    ["My Page", "My Page"],
+    ["Admin", "Admin Dashboard"],
+    ["Admin Boards", "Admin Boards"],
+    ["Admin Posts", "Admin Posts"],
+    ["Admin Comments", "Admin Comments"],
+  ] as const;
+
+  for (const [link, heading] of screens) {
+    await page.getByRole("link", { name: link, exact: true }).click();
+    await expect(page.locator("h1")).toHaveText(heading);
+  }
+});

--- a/Frontend/web-post/package-lock.json
+++ b/Frontend/web-post/package-lock.json
@@ -15,6 +15,7 @@
         "react-router-dom": "^6.28.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.59.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.0.1",
         "@types/react": "^18.3.12",
@@ -903,6 +904,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -2537,6 +2554,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.9",

--- a/Frontend/web-post/package.json
+++ b/Frontend/web-post/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run tests/smoke.test.tsx",
+    "test:smoke": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
@@ -17,6 +18,7 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.12",

--- a/Frontend/web-post/playwright.config.ts
+++ b/Frontend/web-post/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  use: {
+    baseURL: "http://127.0.0.1:3101",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 3101",
+    url: "http://127.0.0.1:3101",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/Frontend/web-post/src/app/styles.css
+++ b/Frontend/web-post/src/app/styles.css
@@ -1,9 +1,136 @@
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: "Segoe UI", sans-serif;
-  background: linear-gradient(180deg, #f6f2e8 0%, #fffaf2 100%);
-  color: #1f1a14;
+  background: #fff;
+  color: #111;
+  font-family: "Segoe UI", "Noto Sans KR", sans-serif;
 }
-a { color: inherit; text-decoration: none; }
-button { font: inherit; }
+
+a {
+  color: #111;
+  text-decoration: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  border: 1px solid #111;
+  background: #111;
+  color: #fff;
+  padding: 8px 12px;
+}
+
+button.secondary {
+  background: #fff;
+  color: #111;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  border: 1px solid #999;
+  background: #fff;
+  color: #111;
+  padding: 8px 10px;
+}
+
+textarea {
+  min-height: 90px;
+  resize: vertical;
+}
+
+.page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 28px 20px 56px;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #ddd;
+}
+
+.nav a {
+  font-size: 14px;
+  text-decoration: underline;
+}
+
+.header {
+  padding: 28px 0;
+}
+
+.eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.header h1 {
+  margin: 8px 0;
+  font-size: 34px;
+}
+
+.header p {
+  margin: 0;
+  color: #444;
+}
+
+.panel {
+  border: 1px solid #ddd;
+  padding: 20px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  border: 1px solid #ddd;
+  padding: 16px;
+}
+
+.stack {
+  display: grid;
+  gap: 12px;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.muted {
+  color: #666;
+}
+
+.error {
+  color: #b00020;
+}
+
+.success {
+  color: #0b6b2b;
+}
+
+pre {
+  overflow: auto;
+  background: #f7f7f7;
+  border: 1px solid #ddd;
+  padding: 12px;
+}

--- a/Frontend/web-post/src/entities/admin/api.ts
+++ b/Frontend/web-post/src/entities/admin/api.ts
@@ -1,0 +1,6 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { AdminDashboard } from "./model";
+
+export const fetchAdminDashboard = () =>
+  unwrap<AdminDashboard>(apiClient.get("/api/v1/admin/dashboard", { headers: authHeader("admin") }));

--- a/Frontend/web-post/src/entities/admin/model.ts
+++ b/Frontend/web-post/src/entities/admin/model.ts
@@ -1,0 +1,7 @@
+export interface AdminDashboard {
+  boardCount: number;
+  postCount: number;
+  commentCount: number;
+  hiddenPostCount: number;
+  hiddenCommentCount: number;
+}

--- a/Frontend/web-post/src/entities/board/api.ts
+++ b/Frontend/web-post/src/entities/board/api.ts
@@ -1,0 +1,12 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { BoardSummary } from "./model";
+
+export const fetchBoards = () => unwrap<BoardSummary[]>(apiClient.get("/api/v1/boards"));
+export const fetchBoard = (boardId: number) => unwrap<BoardSummary>(apiClient.get(`/api/v1/boards/${boardId}`));
+export const createBoard = (payload: { name: string; description: string; displayOrder: number }) =>
+  unwrap<BoardSummary>(apiClient.post("/api/v1/admin/boards", payload, { headers: authHeader("admin") }));
+export const updateBoard = (boardId: number, payload: Partial<BoardSummary>) =>
+  unwrap<BoardSummary>(apiClient.patch(`/api/v1/admin/boards/${boardId}`, payload, { headers: authHeader("admin") }));
+export const deleteBoard = (boardId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/admin/boards/${boardId}`, { headers: authHeader("admin") }));

--- a/Frontend/web-post/src/entities/board/model.ts
+++ b/Frontend/web-post/src/entities/board/model.ts
@@ -1,0 +1,7 @@
+export interface BoardSummary {
+  id: number;
+  name: string;
+  description: string;
+  displayOrder: number;
+  status: string;
+}

--- a/Frontend/web-post/src/entities/comment/api.ts
+++ b/Frontend/web-post/src/entities/comment/api.ts
@@ -1,0 +1,20 @@
+import { apiClient, unwrap, unwrapPaged } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { CommentSummary } from "./model";
+
+export const fetchComments = (postId: number) =>
+  unwrapPaged<CommentSummary>(apiClient.get(`/api/v1/posts/${postId}/comments`, { params: { page: 1, limit: 20 } }));
+export const createComment = (postId: number, content: string) =>
+  unwrap<CommentSummary>(apiClient.post(`/api/v1/posts/${postId}/comments`, { content }, { headers: authHeader("user") }));
+export const updateComment = (commentId: number, content: string) =>
+  unwrap<CommentSummary>(apiClient.patch(`/api/v1/comments/${commentId}`, { content }, { headers: authHeader("user") }));
+export const deleteComment = (commentId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/comments/${commentId}`, { headers: authHeader("user") }));
+export const fetchAdminComments = () =>
+  unwrapPaged<CommentSummary>(
+    apiClient.get("/api/v1/admin/comments", { headers: authHeader("admin"), params: { page: 1, limit: 20 } }),
+  );
+export const changeCommentStatus = (commentId: number, status: "ACTIVE" | "HIDDEN" | "DELETED") =>
+  unwrap<CommentSummary>(
+    apiClient.patch(`/api/v1/admin/comments/${commentId}/status`, { status }, { headers: authHeader("admin") }),
+  );

--- a/Frontend/web-post/src/entities/comment/model.ts
+++ b/Frontend/web-post/src/entities/comment/model.ts
@@ -1,0 +1,7 @@
+export interface CommentSummary {
+  id: number;
+  postId: number;
+  userId: number;
+  content: string;
+  status: string;
+}

--- a/Frontend/web-post/src/entities/like/api.ts
+++ b/Frontend/web-post/src/entities/like/api.ts
@@ -1,0 +1,7 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+
+export const likePost = (postId: number) =>
+  unwrap<{ liked: boolean }>(apiClient.post(`/api/v1/posts/${postId}/likes`, null, { headers: authHeader("user") }));
+export const unlikePost = (postId: number) =>
+  unwrap<{ liked: boolean }>(apiClient.delete(`/api/v1/posts/${postId}/likes`, { headers: authHeader("user") }));

--- a/Frontend/web-post/src/entities/post/api.ts
+++ b/Frontend/web-post/src/entities/post/api.ts
@@ -1,0 +1,19 @@
+import { apiClient, unwrap, unwrapPaged } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { PostDetail, PostSummary } from "./model";
+
+export const fetchPosts = (params?: Record<string, string | number>) =>
+  unwrapPaged<PostSummary>(apiClient.get("/api/v1/posts", { params }));
+export const fetchPostDetail = (postId: number) => unwrap<PostDetail>(apiClient.get(`/api/v1/posts/${postId}`));
+export const createPost = (payload: { boardId: number; title: string; content: string }) =>
+  unwrap<PostDetail>(apiClient.post("/api/v1/posts", payload, { headers: authHeader("user") }));
+export const updatePost = (postId: number, payload: { title?: string; content?: string }) =>
+  unwrap<PostDetail>(apiClient.patch(`/api/v1/posts/${postId}`, payload, { headers: authHeader("user") }));
+export const deletePost = (postId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/posts/${postId}`, { headers: authHeader("user") }));
+export const fetchAdminPosts = () =>
+  unwrapPaged<PostSummary>(
+    apiClient.get("/api/v1/admin/posts", { headers: authHeader("admin"), params: { page: 1, limit: 20 } }),
+  );
+export const changePostStatus = (postId: number, status: "ACTIVE" | "HIDDEN" | "DELETED") =>
+  unwrap<PostSummary>(apiClient.patch(`/api/v1/admin/posts/${postId}/status`, { status }, { headers: authHeader("admin") }));

--- a/Frontend/web-post/src/entities/post/model.ts
+++ b/Frontend/web-post/src/entities/post/model.ts
@@ -1,0 +1,14 @@
+export interface PostSummary {
+  id: number;
+  boardId: number;
+  title: string;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  status: string;
+}
+
+export interface PostDetail extends PostSummary {
+  content: string;
+  author?: { id: number; email: string; nickname: string };
+}

--- a/Frontend/web-post/src/entities/session/api.ts
+++ b/Frontend/web-post/src/entities/session/api.ts
@@ -1,0 +1,61 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import type { HealthPayload } from "../../shared/types";
+import type { AdminMe, TokenPair, UserMe } from "./model";
+import { authHeader, sessionStore } from "./storage";
+
+export const fetchHealth = () => unwrap<HealthPayload>(apiClient.get("/api/v1/health"));
+
+export const signupUser = (payload: { email: string; password: string; nickname: string }) =>
+  unwrap<UserMe>(apiClient.post("/api/v1/auth/signup", payload));
+
+export async function loginUser(payload: { email: string; password: string }) {
+  const tokens = await unwrap<TokenPair>(apiClient.post("/api/v1/auth/login", payload));
+  sessionStore.saveUser(tokens);
+  return tokens;
+}
+
+export async function refreshUser() {
+  const tokens = await unwrap<TokenPair>(
+    apiClient.post("/api/v1/auth/refresh", { refreshToken: sessionStore.userRefresh() }),
+  );
+  sessionStore.saveUser(tokens);
+  return tokens;
+}
+
+export async function logoutUser() {
+  const result = await unwrap<{ message: string }>(
+    apiClient.post("/api/v1/auth/logout", null, { headers: authHeader("user") }),
+  );
+  sessionStore.clearUser();
+  return result;
+}
+
+export const fetchMe = () => unwrap<UserMe>(apiClient.get("/api/v1/users/me", { headers: authHeader("user") }));
+
+export const updateMe = (payload: { nickname: string }) =>
+  unwrap<UserMe>(apiClient.patch("/api/v1/users/me", payload, { headers: authHeader("user") }));
+
+export async function loginAdmin(payload: { email: string; password: string }) {
+  const tokens = await unwrap<TokenPair>(apiClient.post("/api/v1/admin/auth/login", payload));
+  sessionStore.saveAdmin(tokens);
+  return tokens;
+}
+
+export async function refreshAdmin() {
+  const tokens = await unwrap<TokenPair>(
+    apiClient.post("/api/v1/admin/auth/refresh", { refreshToken: sessionStore.adminRefresh() }),
+  );
+  sessionStore.saveAdmin(tokens);
+  return tokens;
+}
+
+export async function logoutAdmin() {
+  const result = await unwrap<{ message: string }>(
+    apiClient.post("/api/v1/admin/auth/logout", null, { headers: authHeader("admin") }),
+  );
+  sessionStore.clearAdmin();
+  return result;
+}
+
+export const fetchAdminMe = () =>
+  unwrap<AdminMe>(apiClient.get("/api/v1/admin/me", { headers: authHeader("admin") }));

--- a/Frontend/web-post/src/entities/session/model.ts
+++ b/Frontend/web-post/src/entities/session/model.ts
@@ -1,0 +1,18 @@
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface UserMe {
+  id: number;
+  email: string;
+  nickname: string;
+  status: string;
+}
+
+export interface AdminMe {
+  id: number;
+  email: string;
+  name: string;
+  status: string;
+}

--- a/Frontend/web-post/src/entities/session/storage.ts
+++ b/Frontend/web-post/src/entities/session/storage.ts
@@ -1,0 +1,36 @@
+import type { TokenPair } from "./model";
+
+const userTokenKey = "web-post-user-access-token";
+const userRefreshKey = "web-post-user-refresh-token";
+const adminTokenKey = "web-post-admin-access-token";
+const adminRefreshKey = "web-post-admin-refresh-token";
+
+const read = (key: string) => window.localStorage.getItem(key) ?? "";
+const write = (key: string, value: string) => window.localStorage.setItem(key, value);
+const remove = (key: string) => window.localStorage.removeItem(key);
+
+export function authHeader(kind: "user" | "admin") {
+  const token = kind === "user" ? read(userTokenKey) : read(adminTokenKey);
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export const sessionStore = {
+  userRefresh: () => read(userRefreshKey),
+  adminRefresh: () => read(adminRefreshKey),
+  saveUser(tokens: TokenPair) {
+    write(userTokenKey, tokens.accessToken);
+    write(userRefreshKey, tokens.refreshToken);
+  },
+  saveAdmin(tokens: TokenPair) {
+    write(adminTokenKey, tokens.accessToken);
+    write(adminRefreshKey, tokens.refreshToken);
+  },
+  clearUser() {
+    remove(userTokenKey);
+    remove(userRefreshKey);
+  },
+  clearAdmin() {
+    remove(adminTokenKey);
+    remove(adminRefreshKey);
+  },
+};

--- a/Frontend/web-post/src/features/admin-board-manage/AdminBoardManager.tsx
+++ b/Frontend/web-post/src/features/admin-board-manage/AdminBoardManager.tsx
@@ -1,0 +1,47 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createBoard, deleteBoard, updateBoard } from "../../entities/board/api";
+import type { BoardSummary } from "../../entities/board/model";
+
+interface Props {
+  boards: BoardSummary[];
+}
+
+export function AdminBoardManager({ boards }: Props) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("frontend-board");
+  const [description, setDescription] = useState("Board from frontend admin");
+  const [displayOrder, setDisplayOrder] = useState(10);
+  const reload = () => queryClient.invalidateQueries({ queryKey: ["boards"] });
+  const create = useMutation({ mutationFn: () => createBoard({ name, description, displayOrder }), onSuccess: reload });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    create.mutate();
+  }
+
+  return (
+    <>
+      <form className="grid" onSubmit={submit}>
+        <input value={name} onChange={(event) => setName(event.target.value)} />
+        <input value={description} onChange={(event) => setDescription(event.target.value)} />
+        <input type="number" value={displayOrder} onChange={(event) => setDisplayOrder(Number(event.target.value))} />
+        <button type="submit">Create board</button>
+      </form>
+      <div className="stack">
+        {boards.map((board) => (
+          <div className="card row" key={board.id}>
+            <strong>#{board.id} {board.name}</strong>
+            <span>{board.status}</span>
+            <button className="secondary" type="button" onClick={() => updateBoard(board.id, { status: "HIDDEN" }).then(reload)}>
+              Hide
+            </button>
+            <button className="secondary" type="button" onClick={() => deleteBoard(board.id).then(reload)}>
+              Delete
+            </button>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-post/src/features/admin-comment-moderate/AdminCommentModeration.tsx
+++ b/Frontend/web-post/src/features/admin-comment-moderate/AdminCommentModeration.tsx
@@ -1,0 +1,27 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { changeCommentStatus } from "../../entities/comment/api";
+import type { CommentSummary } from "../../entities/comment/model";
+
+interface Props {
+  comments: CommentSummary[];
+}
+
+export function AdminCommentModeration({ comments }: Props) {
+  const queryClient = useQueryClient();
+  const reload = () => queryClient.invalidateQueries({ queryKey: ["admin-comments"] });
+
+  return (
+    <div className="stack">
+      {comments.map((comment) => (
+        <div className="card row" key={comment.id}>
+          <span>#{comment.id} {comment.content}</span>
+          <span>{comment.status}</span>
+          <button type="button" onClick={() => changeCommentStatus(comment.id, "ACTIVE").then(reload)}>Active</button>
+          <button className="secondary" type="button" onClick={() => changeCommentStatus(comment.id, "HIDDEN").then(reload)}>
+            Hidden
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Frontend/web-post/src/features/admin-post-moderate/AdminPostModeration.tsx
+++ b/Frontend/web-post/src/features/admin-post-moderate/AdminPostModeration.tsx
@@ -1,0 +1,27 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { changePostStatus } from "../../entities/post/api";
+import type { PostSummary } from "../../entities/post/model";
+
+interface Props {
+  posts: PostSummary[];
+}
+
+export function AdminPostModeration({ posts }: Props) {
+  const queryClient = useQueryClient();
+  const reload = () => queryClient.invalidateQueries({ queryKey: ["admin-posts"] });
+
+  return (
+    <div className="stack">
+      {posts.map((post) => (
+        <div className="card row" key={post.id}>
+          <strong>#{post.id} {post.title}</strong>
+          <span>{post.status}</span>
+          <button type="button" onClick={() => changePostStatus(post.id, "ACTIVE").then(reload)}>Active</button>
+          <button className="secondary" type="button" onClick={() => changePostStatus(post.id, "HIDDEN").then(reload)}>
+            Hidden
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Frontend/web-post/src/features/auth-admin/AdminLoginPanel.tsx
+++ b/Frontend/web-post/src/features/auth-admin/AdminLoginPanel.tsx
@@ -1,0 +1,38 @@
+import { FormEvent, useState } from "react";
+import { loginAdmin, logoutAdmin, refreshAdmin } from "../../entities/session/api";
+
+export function AdminLoginPanel() {
+  const [email, setEmail] = useState("admin-post-1@example.com");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setError("");
+    try {
+      await loginAdmin({ email, password: "AdminPassword1!" });
+      setMessage("Admin login saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Admin login failed");
+    }
+  }
+
+  return (
+    <form className="card stack" onSubmit={submit}>
+      <h2>Admin</h2>
+      <label>
+        Email
+        <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      </label>
+      <button type="submit">Login admin</button>
+      <button className="secondary" type="button" onClick={() => refreshAdmin().then(() => setMessage("Admin token refreshed."))}>
+        Refresh admin
+      </button>
+      <button className="secondary" type="button" onClick={() => logoutAdmin().then(() => setMessage("Admin logged out."))}>
+        Logout admin
+      </button>
+      {message && <p className="success">{message}</p>}
+      {error && <p className="error">{error}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-post/src/features/auth-user/UserLoginPanel.tsx
+++ b/Frontend/web-post/src/features/auth-user/UserLoginPanel.tsx
@@ -1,0 +1,38 @@
+import { FormEvent, useState } from "react";
+import { loginUser, logoutUser, refreshUser } from "../../entities/session/api";
+
+export function UserLoginPanel() {
+  const [email, setEmail] = useState("post-user-1@example.com");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setError("");
+    try {
+      await loginUser({ email, password: "Password1!" });
+      setMessage("User login saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "User login failed");
+    }
+  }
+
+  return (
+    <form className="card stack" onSubmit={submit}>
+      <h2>User</h2>
+      <label>
+        Email
+        <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      </label>
+      <button type="submit">Login user</button>
+      <button className="secondary" type="button" onClick={() => refreshUser().then(() => setMessage("User token refreshed."))}>
+        Refresh user
+      </button>
+      <button className="secondary" type="button" onClick={() => logoutUser().then(() => setMessage("User logged out."))}>
+        Logout user
+      </button>
+      {message && <p className="success">{message}</p>}
+      {error && <p className="error">{error}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-post/src/features/comment-create/CreateCommentForm.tsx
+++ b/Frontend/web-post/src/features/comment-create/CreateCommentForm.tsx
@@ -1,0 +1,28 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createComment } from "../../entities/comment/api";
+
+interface Props {
+  postId: number;
+}
+
+export function CreateCommentForm({ postId }: Props) {
+  const queryClient = useQueryClient();
+  const [content, setContent] = useState("Comment from frontend");
+  const create = useMutation({
+    mutationFn: () => createComment(postId, content),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["comments", postId] }),
+  });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    create.mutate();
+  }
+
+  return (
+    <form className="stack" onSubmit={submit}>
+      <textarea value={content} onChange={(event) => setContent(event.target.value)} />
+      <button type="submit">Add comment</button>
+    </form>
+  );
+}

--- a/Frontend/web-post/src/features/comment-edit/DeleteCommentButton.tsx
+++ b/Frontend/web-post/src/features/comment-edit/DeleteCommentButton.tsx
@@ -1,0 +1,20 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { deleteComment } from "../../entities/comment/api";
+
+interface Props {
+  commentId: number;
+  postId: number;
+}
+
+export function DeleteCommentButton({ commentId, postId }: Props) {
+  const queryClient = useQueryClient();
+  return (
+    <button
+      className="secondary"
+      type="button"
+      onClick={() => deleteComment(commentId).then(() => queryClient.invalidateQueries({ queryKey: ["comments", postId] }))}
+    >
+      Delete
+    </button>
+  );
+}

--- a/Frontend/web-post/src/features/post-create/CreatePostForm.tsx
+++ b/Frontend/web-post/src/features/post-create/CreatePostForm.tsx
@@ -1,0 +1,29 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createPost } from "../../entities/post/api";
+
+export function CreatePostForm() {
+  const queryClient = useQueryClient();
+  const [boardId, setBoardId] = useState(1);
+  const [title, setTitle] = useState("New post from frontend");
+  const [content, setContent] = useState("Simple content");
+  const create = useMutation({
+    mutationFn: () => createPost({ boardId, title, content }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["posts"] }),
+  });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    create.mutate();
+  }
+
+  return (
+    <form className="stack" onSubmit={submit}>
+      <input type="number" value={boardId} onChange={(event) => setBoardId(Number(event.target.value))} />
+      <input value={title} onChange={(event) => setTitle(event.target.value)} />
+      <textarea value={content} onChange={(event) => setContent(event.target.value)} />
+      <button type="submit">Create</button>
+      {create.error && <p className="error">{create.error.message}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-post/src/features/post-edit/UpdatePostTitleForm.tsx
+++ b/Frontend/web-post/src/features/post-edit/UpdatePostTitleForm.tsx
@@ -1,0 +1,28 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { updatePost } from "../../entities/post/api";
+
+interface Props {
+  postId: number;
+}
+
+export function UpdatePostTitleForm({ postId }: Props) {
+  const queryClient = useQueryClient();
+  const [title, setTitle] = useState("");
+  const update = useMutation({
+    mutationFn: () => updatePost(postId, { title }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["post-detail", postId] }),
+  });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    update.mutate();
+  }
+
+  return (
+    <form className="row" onSubmit={submit}>
+      <input placeholder="New title" value={title} onChange={(event) => setTitle(event.target.value)} />
+      <button type="submit">Update title</button>
+    </form>
+  );
+}

--- a/Frontend/web-post/src/features/post-like/PostLikeActions.tsx
+++ b/Frontend/web-post/src/features/post-like/PostLikeActions.tsx
@@ -1,0 +1,20 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { likePost, unlikePost } from "../../entities/like/api";
+
+interface Props {
+  postId: number;
+}
+
+export function PostLikeActions({ postId }: Props) {
+  const queryClient = useQueryClient();
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ["post-detail", postId] });
+  const like = useMutation({ mutationFn: () => likePost(postId), onSuccess: invalidate });
+  const unlike = useMutation({ mutationFn: () => unlikePost(postId), onSuccess: invalidate });
+
+  return (
+    <div className="row">
+      <button type="button" onClick={() => like.mutate()}>Like</button>
+      <button className="secondary" type="button" onClick={() => unlike.mutate()}>Unlike</button>
+    </div>
+  );
+}

--- a/Frontend/web-post/src/features/signup-user/SignupUserForm.tsx
+++ b/Frontend/web-post/src/features/signup-user/SignupUserForm.tsx
@@ -1,0 +1,29 @@
+import { FormEvent, useState } from "react";
+import { signupUser } from "../../entities/session/api";
+
+export function SignupUserForm() {
+  const [email, setEmail] = useState(`post-${Date.now()}@example.com`);
+  const [nickname, setNickname] = useState("new-writer");
+  const [result, setResult] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const user = await signupUser({ email, nickname, password: "Password1!" });
+    setResult(`Created user #${user.id} ${user.email}`);
+  }
+
+  return (
+    <form className="stack" onSubmit={submit}>
+      <label>
+        Email
+        <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      </label>
+      <label>
+        Nickname
+        <input value={nickname} onChange={(event) => setNickname(event.target.value)} />
+      </label>
+      <button type="submit">Create user</button>
+      {result && <p className="success">{result}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-post/src/pages/admin-boards/page.tsx
+++ b/Frontend/web-post/src/pages/admin-boards/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminBoardPanel } from "../../widgets/admin-board-panel/AdminBoardPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminBoardsPage() {
-  return <PageShell title="Admin Boards" description="web-post::admin-boards" />;
+  return (
+    <PageShell title="Admin Boards" description="관리자 게시판 CRUD입니다.">
+      <AdminBoardPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-post/src/pages/admin-comments/page.tsx
+++ b/Frontend/web-post/src/pages/admin-comments/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminCommentPanel } from "../../widgets/admin-comment-panel/AdminCommentPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminCommentsPage() {
-  return <PageShell title="Admin Comments" description="web-post::admin-comments" />;
+  return (
+    <PageShell title="Admin Comments" description="댓글 상태를 운영합니다.">
+      <AdminCommentPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-post/src/pages/admin-dashboard/page.tsx
+++ b/Frontend/web-post/src/pages/admin-dashboard/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminDashboardPanel } from "../../widgets/admin-dashboard-panel/AdminDashboardPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminDashboardPage() {
-  return <PageShell title="Admin Dashboard" description="web-post::admin-dashboard" />;
+  return (
+    <PageShell title="Admin Dashboard" description="관리자 계정과 게시판 운영 요약입니다.">
+      <AdminDashboardPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-post/src/pages/admin-posts/page.tsx
+++ b/Frontend/web-post/src/pages/admin-posts/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminPostPanel } from "../../widgets/admin-post-panel/AdminPostPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminPostsPage() {
-  return <PageShell title="Admin Posts" description="web-post::admin-posts" />;
+  return (
+    <PageShell title="Admin Posts" description="게시글 상태를 운영합니다.">
+      <AdminPostPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-post/src/pages/boards/page.tsx
+++ b/Frontend/web-post/src/pages/boards/page.tsx
@@ -1,1 +1,10 @@
-import { useQuery } from "@tanstack/react-query"; import { fetchBoards, fetchPosts } from "../../shared/api/client"; import { PageShell } from "../../shared/ui/PageShell"; export function BoardsPage() { const boards = useQuery({ queryKey: ["boards"], queryFn: fetchBoards }); const posts = useQuery({ queryKey: ["posts"], queryFn: fetchPosts }); return (<PageShell title="Boards" description="web-post::boards"><h2>Boards</h2><ul>{(boards.data ?? []).map((item) => (<li key={item.id}>{item.name} / {item.status}</li>))}</ul><h2>Posts</h2><ul>{(posts.data ?? []).map((item) => (<li key={item.id}>{item.title} / views {item.viewCount}</li>))}</ul></PageShell>); }
+import { BoardPostsPanel } from "../../widgets/board-posts-panel/BoardPostsPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
+
+export function BoardsPage() {
+  return (
+    <PageShell title="Boards" description="게시판 목록, 게시글 목록, 게시글 작성을 확인합니다.">
+      <BoardPostsPanel />
+    </PageShell>
+  );
+}

--- a/Frontend/web-post/src/pages/home/page.tsx
+++ b/Frontend/web-post/src/pages/home/page.tsx
@@ -1,1 +1,10 @@
-import { useQuery } from "@tanstack/react-query"; import { fetchHealth } from "../../shared/api/client"; import { PageShell } from "../../shared/ui/PageShell"; export function HomePage() { const { data, isLoading } = useQuery({ queryKey: ["health"], queryFn: fetchHealth }); return (<PageShell title="Home" description="web-post::home"><p>API Base: {import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000"}</p><p>{isLoading ? "Loading health..." : `Status: ${data?.status} / ${data?.service}`}</p></PageShell>); }
+import { HomeSummary } from "../../widgets/home-summary/HomeSummary";
+import { PageShell } from "../../widgets/app-shell/PageShell";
+
+export function HomePage() {
+  return (
+    <PageShell title="Post Home" description="게시판 서비스의 주요 상태와 최신 글을 확인합니다.">
+      <HomeSummary />
+    </PageShell>
+  );
+}

--- a/Frontend/web-post/src/pages/login/page.tsx
+++ b/Frontend/web-post/src/pages/login/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { LoginPanel } from "../../widgets/app-shell/LoginPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function LoginPage() {
-  return <PageShell title="Login" description="web-post::login" />;
+  return (
+    <PageShell title="Login" description="사용자와 관리자를 분리해서 로그인합니다.">
+      <LoginPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-post/src/pages/mypage/page.tsx
+++ b/Frontend/web-post/src/pages/mypage/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { MypagePanel } from "../../widgets/mypage-panel/MypagePanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function MypagePage() {
-  return <PageShell title="My Page" description="web-post::mypage" />;
+  return (
+    <PageShell title="My Page" description="로그인한 사용자 정보를 확인하고 수정합니다.">
+      <MypagePanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-post/src/pages/post-detail/page.tsx
+++ b/Frontend/web-post/src/pages/post-detail/page.tsx
@@ -1,1 +1,10 @@
-import { useQuery } from "@tanstack/react-query"; import { fetchPostDetail } from "../../shared/api/client"; import { PageShell } from "../../shared/ui/PageShell"; export function PostDetailPage() { const query = useQuery({ queryKey: ["post-detail", 1], queryFn: () => fetchPostDetail(1) }); return (<PageShell title="Post Detail" description="web-post::post-detail"><pre>{JSON.stringify(query.data ?? { message: "Loading..." }, null, 2)}</pre></PageShell>); }
+import { PostDetailPanel } from "../../widgets/post-detail-panel/PostDetailPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
+
+export function PostDetailPage() {
+  return (
+    <PageShell title="Post Detail" description="게시글 상세, 댓글, 좋아요를 확인합니다.">
+      <PostDetailPanel />
+    </PageShell>
+  );
+}

--- a/Frontend/web-post/src/pages/signup/page.tsx
+++ b/Frontend/web-post/src/pages/signup/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { SignupUserForm } from "../../features/signup-user/SignupUserForm";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function SignupPage() {
-  return <PageShell title="Signup" description="web-post::signup" />;
+  return (
+    <PageShell title="Signup" description="게시판 사용자 계정을 생성합니다.">
+      <SignupUserForm />
+    </PageShell>
+  );
 }

--- a/Frontend/web-post/src/shared/api/client.ts
+++ b/Frontend/web-post/src/shared/api/client.ts
@@ -1,1 +1,21 @@
-import axios from "axios"; import { env } from "../config/env"; import type { ApiEnvelope, BoardSummary, HealthPayload, PostDetail, PostSummary } from "../types"; export const apiClient = axios.create({ baseURL: env.apiBaseUrl, timeout: 5000 }); async function unwrap<T>(request: Promise<{ data: ApiEnvelope<T> }>) { const response = await request; if (!response.data.success || response.data.data === null) throw new Error(response.data.error?.message ?? "Request failed"); return response.data.data; } export const fetchHealth = () => unwrap<HealthPayload>(apiClient.get("/api/v1/health")); export const fetchBoards = () => unwrap<BoardSummary[]>(apiClient.get("/api/v1/boards")); export const fetchPosts = () => unwrap<PostSummary[]>(apiClient.get("/api/v1/posts")); export const fetchPostDetail = (postId: number) => unwrap<PostDetail>(apiClient.get(`/api/v1/posts/${postId}`));
+import axios from "axios";
+import { env } from "../config/env";
+import type { ApiEnvelope, PagedResult, PageMeta } from "../types";
+
+export const apiClient = axios.create({ baseURL: env.apiBaseUrl, timeout: 8000 });
+
+export async function unwrap<T>(request: Promise<{ data: ApiEnvelope<T> }>) {
+  const response = await request;
+  if (!response.data.success || response.data.data === null) {
+    throw new Error(response.data.error?.message ?? "Request failed");
+  }
+  return response.data.data;
+}
+
+export async function unwrapPaged<T>(request: Promise<{ data: ApiEnvelope<T[]> }>): Promise<PagedResult<T>> {
+  const response = await request;
+  if (!response.data.success || response.data.data === null) {
+    throw new Error(response.data.error?.message ?? "Request failed");
+  }
+  return { data: response.data.data, meta: (response.data.meta as PageMeta | undefined) ?? null };
+}

--- a/Frontend/web-post/src/shared/types/index.ts
+++ b/Frontend/web-post/src/shared/types/index.ts
@@ -1,8 +1,24 @@
-export interface ApiEnvelope<T> { success: boolean; data: T | null; meta?: Record<string, unknown> | null; error?: { code: string; message: string; details?: unknown } | null; }
-export interface HealthPayload { status: string; service: string; domain: string; }
-export interface BoardSummary { id: number; name: string; description: string; displayOrder: number; status: string; }
-export interface PostSummary { id: number; boardId: number; title: string; viewCount: number; likeCount: number; commentCount: number; status: string; }
-export interface PostDetail extends PostSummary { content: string; }
-export interface CategorySummary { id: number; name: string; displayOrder: number; status: string; }
-export interface ProductSummary { id: number; categoryId: number; name: string; price: number; stock: number; status: string; }
-export interface ProductDetail extends ProductSummary { description: string; }
+export interface ApiEnvelope<T> {
+  success: boolean;
+  data: T | null;
+  meta?: PageMeta | null;
+  error?: { code: string; message: string; details?: unknown } | null;
+}
+
+export interface PageMeta {
+  page: number;
+  limit: number;
+  totalCount: number;
+  totalPages: number;
+}
+
+export interface HealthPayload {
+  status: string;
+  service: string;
+  domain: string;
+}
+
+export interface PagedResult<T> {
+  data: T[];
+  meta: PageMeta | null;
+}

--- a/Frontend/web-post/src/shared/ui/PageShell.tsx
+++ b/Frontend/web-post/src/shared/ui/PageShell.tsx
@@ -1,3 +1,0 @@
-import { PropsWithChildren } from "react";
-interface Props extends PropsWithChildren { title: string; description: string; }
-export function PageShell({ title, description, children }: Props) { return (<main style={{ maxWidth: 1080, margin: "0 auto", padding: "48px 24px" }}><header style={{ marginBottom: 24 }}><div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 1.2, color: "#7a5d3a" }}>Project-Bible</div><h1 style={{ margin: "8px 0 0", fontSize: 36 }}>{title}</h1><p style={{ color: "#5d5144" }}>{description}</p></header><section style={{ padding: 24, borderRadius: 20, background: "#fff", border: "1px solid #eadcc7" }}>{children ?? <p>Baseline page is ready.</p>}</section></main>); }

--- a/Frontend/web-post/src/widgets/admin-board-panel/AdminBoardPanel.tsx
+++ b/Frontend/web-post/src/widgets/admin-board-panel/AdminBoardPanel.tsx
@@ -1,0 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchBoards } from "../../entities/board/api";
+import { AdminBoardManager } from "../../features/admin-board-manage/AdminBoardManager";
+
+export function AdminBoardPanel() {
+  const boards = useQuery({ queryKey: ["boards", "admin"], queryFn: fetchBoards });
+  return <AdminBoardManager boards={boards.data ?? []} />;
+}

--- a/Frontend/web-post/src/widgets/admin-comment-panel/AdminCommentPanel.tsx
+++ b/Frontend/web-post/src/widgets/admin-comment-panel/AdminCommentPanel.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminComments } from "../../entities/comment/api";
+import { AdminCommentModeration } from "../../features/admin-comment-moderate/AdminCommentModeration";
+
+export function AdminCommentPanel() {
+  const comments = useQuery({ queryKey: ["admin-comments"], queryFn: fetchAdminComments });
+  return (
+    <>
+      <p className="muted">Total: {comments.data?.meta?.totalCount ?? 0}</p>
+      <AdminCommentModeration comments={comments.data?.data ?? []} />
+    </>
+  );
+}

--- a/Frontend/web-post/src/widgets/admin-dashboard-panel/AdminDashboardPanel.tsx
+++ b/Frontend/web-post/src/widgets/admin-dashboard-panel/AdminDashboardPanel.tsx
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminDashboard } from "../../entities/admin/api";
+import { fetchAdminMe } from "../../entities/session/api";
+
+export function AdminDashboardPanel() {
+  const me = useQuery({ queryKey: ["admin-me"], queryFn: fetchAdminMe, retry: false });
+  const dashboard = useQuery({ queryKey: ["admin-dashboard"], queryFn: fetchAdminDashboard, retry: false });
+
+  return (
+    <>
+      {me.error && <p className="error">Login as admin first.</p>}
+      {me.data && <p>Admin: {me.data.email}</p>}
+      {dashboard.data && (
+        <div className="grid">
+          <div className="card">Boards: {dashboard.data.boardCount}</div>
+          <div className="card">Posts: {dashboard.data.postCount}</div>
+          <div className="card">Comments: {dashboard.data.commentCount}</div>
+          <div className="card">Hidden posts: {dashboard.data.hiddenPostCount}</div>
+          <div className="card">Hidden comments: {dashboard.data.hiddenCommentCount}</div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/Frontend/web-post/src/widgets/admin-post-panel/AdminPostPanel.tsx
+++ b/Frontend/web-post/src/widgets/admin-post-panel/AdminPostPanel.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminPosts } from "../../entities/post/api";
+import { AdminPostModeration } from "../../features/admin-post-moderate/AdminPostModeration";
+
+export function AdminPostPanel() {
+  const posts = useQuery({ queryKey: ["admin-posts"], queryFn: fetchAdminPosts });
+  return (
+    <>
+      <p className="muted">Total: {posts.data?.meta?.totalCount ?? 0}</p>
+      <AdminPostModeration posts={posts.data?.data ?? []} />
+    </>
+  );
+}

--- a/Frontend/web-post/src/widgets/app-shell/LoginPanel.tsx
+++ b/Frontend/web-post/src/widgets/app-shell/LoginPanel.tsx
@@ -1,0 +1,11 @@
+import { AdminLoginPanel } from "../../features/auth-admin/AdminLoginPanel";
+import { UserLoginPanel } from "../../features/auth-user/UserLoginPanel";
+
+export function LoginPanel() {
+  return (
+    <div className="grid">
+      <UserLoginPanel />
+      <AdminLoginPanel />
+    </div>
+  );
+}

--- a/Frontend/web-post/src/widgets/app-shell/PageShell.tsx
+++ b/Frontend/web-post/src/widgets/app-shell/PageShell.tsx
@@ -1,0 +1,40 @@
+import { PropsWithChildren } from "react";
+import { Link } from "react-router-dom";
+
+interface Props extends PropsWithChildren {
+  title: string;
+  description: string;
+}
+
+const links = [
+  ["/", "Home"],
+  ["/login", "Login"],
+  ["/signup", "Signup"],
+  ["/boards", "Boards"],
+  ["/post-detail", "Post Detail"],
+  ["/mypage", "My Page"],
+  ["/admin-dashboard", "Admin"],
+  ["/admin-boards", "Admin Boards"],
+  ["/admin-posts", "Admin Posts"],
+  ["/admin-comments", "Admin Comments"],
+];
+
+export function PageShell({ title, description, children }: Props) {
+  return (
+    <main className="page">
+      <nav className="nav">
+        {links.map(([to, label]) => (
+          <Link key={to} to={to}>
+            {label}
+          </Link>
+        ))}
+      </nav>
+      <header className="header">
+        <div className="eyebrow">Project-Bible Post</div>
+        <h1>{title}</h1>
+        <p>{description}</p>
+      </header>
+      <section className="panel">{children}</section>
+    </main>
+  );
+}

--- a/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
+++ b/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchBoards } from "../../entities/board/api";
+import { fetchPosts } from "../../entities/post/api";
+import { CreatePostForm } from "../../features/post-create/CreatePostForm";
+
+export function BoardPostsPanel() {
+  const boards = useQuery({ queryKey: ["boards"], queryFn: fetchBoards });
+  const posts = useQuery({ queryKey: ["posts"], queryFn: () => fetchPosts({ page: 1, limit: 20, sort: "latest" }) });
+
+  return (
+    <>
+      <div className="grid">
+        <section>
+          <h2>Boards</h2>
+          <div className="stack">
+            {(boards.data ?? []).map((board) => (
+              <div className="card" key={board.id}>
+                <strong>{board.name}</strong>
+                <p>{board.description}</p>
+                <p className="muted">#{board.id} / {board.status}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+        <section>
+          <h2>Create post</h2>
+          <CreatePostForm />
+        </section>
+      </div>
+      <h2>Posts</h2>
+      <div className="stack">
+        {(posts.data?.data ?? []).map((post) => (
+          <div className="card" key={post.id}>
+            <strong>#{post.id} {post.title}</strong>
+            <p className="muted">
+              board {post.boardId} / views {post.viewCount} / likes {post.likeCount} / comments {post.commentCount} / {post.status}
+            </p>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
+++ b/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
@@ -1,0 +1,42 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchBoards } from "../../entities/board/api";
+import { fetchPosts } from "../../entities/post/api";
+import { fetchHealth } from "../../entities/session/api";
+import { env } from "../../shared/config/env";
+
+export function HomeSummary() {
+  const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
+  const boards = useQuery({ queryKey: ["boards", "home"], queryFn: fetchBoards });
+  const posts = useQuery({ queryKey: ["posts", "home"], queryFn: () => fetchPosts({ page: 1, limit: 5 }) });
+
+  return (
+    <>
+      <div className="grid">
+        <div className="card">
+          <h2>API</h2>
+          <p className="muted">{env.apiBaseUrl}</p>
+          <p>{health.isLoading ? "Checking..." : `${health.data?.status} / ${health.data?.service}`}</p>
+        </div>
+        <div className="card">
+          <h2>Boards</h2>
+          <p>{boards.data?.length ?? 0} boards loaded</p>
+        </div>
+        <div className="card">
+          <h2>Posts</h2>
+          <p>{posts.data?.meta?.totalCount ?? 0} total posts</p>
+        </div>
+      </div>
+      <h2>Recent posts</h2>
+      <div className="stack">
+        {(posts.data?.data ?? []).map((post) => (
+          <div className="card" key={post.id}>
+            <strong>{post.title}</strong>
+            <p className="muted">
+              views {post.viewCount} / likes {post.likeCount} / comments {post.commentCount}
+            </p>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-post/src/widgets/mypage-panel/MypagePanel.tsx
+++ b/Frontend/web-post/src/widgets/mypage-panel/MypagePanel.tsx
@@ -1,0 +1,39 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetchMe, updateMe } from "../../entities/session/api";
+
+export function MypagePanel() {
+  const queryClient = useQueryClient();
+  const me = useQuery({ queryKey: ["me"], queryFn: fetchMe, retry: false });
+  const [nickname, setNickname] = useState("");
+  const update = useMutation({
+    mutationFn: () => updateMe({ nickname }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["me"] }),
+  });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    update.mutate();
+  }
+
+  return (
+    <>
+      {me.error && <p className="error">Login as user first.</p>}
+      {me.data && (
+        <div className="card">
+          <p>ID: {me.data.id}</p>
+          <p>Email: {me.data.email}</p>
+          <p>Nickname: {me.data.nickname}</p>
+          <p>Status: {me.data.status}</p>
+        </div>
+      )}
+      <form className="stack" onSubmit={submit}>
+        <label>
+          New nickname
+          <input value={nickname} onChange={(event) => setNickname(event.target.value)} />
+        </label>
+        <button type="submit">Update</button>
+      </form>
+    </>
+  );
+}

--- a/Frontend/web-post/src/widgets/post-detail-panel/PostDetailPanel.tsx
+++ b/Frontend/web-post/src/widgets/post-detail-panel/PostDetailPanel.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchComments } from "../../entities/comment/api";
+import { fetchPostDetail } from "../../entities/post/api";
+import { CreateCommentForm } from "../../features/comment-create/CreateCommentForm";
+import { DeleteCommentButton } from "../../features/comment-edit/DeleteCommentButton";
+import { PostLikeActions } from "../../features/post-like/PostLikeActions";
+import { UpdatePostTitleForm } from "../../features/post-edit/UpdatePostTitleForm";
+
+export function PostDetailPanel() {
+  const [postId, setPostId] = useState(1);
+  const detail = useQuery({ queryKey: ["post-detail", postId], queryFn: () => fetchPostDetail(postId) });
+  const comments = useQuery({ queryKey: ["comments", postId], queryFn: () => fetchComments(postId) });
+
+  return (
+    <div className="stack">
+      <label>
+        Post ID
+        <input type="number" value={postId} onChange={(event) => setPostId(Number(event.target.value))} />
+      </label>
+      {detail.data && (
+        <div className="card">
+          <h2>{detail.data.title}</h2>
+          <p>{detail.data.content}</p>
+          <p className="muted">
+            views {detail.data.viewCount} / likes {detail.data.likeCount} / comments {detail.data.commentCount}
+          </p>
+          <PostLikeActions postId={postId} />
+        </div>
+      )}
+      <UpdatePostTitleForm postId={postId} />
+      <CreateCommentForm postId={postId} />
+      <h2>Comments</h2>
+      {(comments.data?.data ?? []).map((item) => (
+        <div className="card row" key={item.id}>
+          <span>{item.content}</span>
+          <span className="muted">{item.status}</span>
+          <DeleteCommentButton commentId={item.id} postId={postId} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Frontend/web-shop/e2e/navigation.spec.ts
+++ b/Frontend/web-shop/e2e/navigation.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from "@playwright/test";
+
+const envelope = (data: unknown, meta?: unknown) => ({
+  success: true,
+  data,
+  ...(meta ? { meta } : {}),
+});
+
+test.beforeEach(async ({ page }) => {
+  await page.route("**/api/v1/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+
+    if (path === "/api/v1/health") {
+      await route.fulfill({ json: envelope({ status: "UP", service: "web-shop-smoke" }) });
+      return;
+    }
+    if (path === "/api/v1/categories") {
+      await route.fulfill({ json: envelope([{ id: 1, name: "Books", displayOrder: 1, status: "ACTIVE" }]) });
+      return;
+    }
+    if (path.startsWith("/api/v1/products") || path.startsWith("/api/v1/admin/products")) {
+      await route.fulfill({
+        json: envelope(
+          [{ id: 1, categoryId: 1, name: "Smoke product", price: 10000, stock: 10, status: "ACTIVE" }],
+          { page: 1, limit: 20, totalCount: 1, totalPages: 1 },
+        ),
+      });
+      return;
+    }
+    if (path.startsWith("/api/v1/cart-items")) {
+      await route.fulfill({ json: envelope([{ id: 1, productId: 1, productOptionId: 1, quantity: 1 }]) });
+      return;
+    }
+    if (path.startsWith("/api/v1/addresses")) {
+      await route.fulfill({ json: envelope([{ id: 1, recipientName: "Smoke", address1: "Seoul", isDefault: true }]) });
+      return;
+    }
+    if (path.startsWith("/api/v1/orders") || path.startsWith("/api/v1/admin/orders")) {
+      await route.fulfill({
+        json: envelope(
+          [{ id: 1, orderNumber: "SMOKE-1", orderStatus: "PAID", totalAmount: 10000 }],
+          { page: 1, limit: 20, totalCount: 1, totalPages: 1 },
+        ),
+      });
+      return;
+    }
+    if (path.startsWith("/api/v1/admin/reviews") || path.includes("/reviews")) {
+      await route.fulfill({
+        json: envelope(
+          [{ id: 1, productId: 1, rating: 5, content: "Smoke review", status: "ACTIVE" }],
+          { page: 1, limit: 20, totalCount: 1, totalPages: 1 },
+        ),
+      });
+      return;
+    }
+    if (path === "/api/v1/admin/dashboard") {
+      await route.fulfill({ json: envelope({ orderCount: 1, productCount: 1, userCount: 1, reviewCount: 1 }) });
+      return;
+    }
+    if (path.includes("/auth/login")) {
+      await route.fulfill({ json: envelope({ accessToken: "access-token", refreshToken: "refresh-token" }) });
+      return;
+    }
+
+    await route.fulfill({ json: envelope({ message: "ok" }) });
+  });
+});
+
+test("navigates core shop screens", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.locator("h1")).toHaveText("Shop Home");
+
+  const screens = [
+    ["Login", "Login"],
+    ["Signup", "Signup"],
+    ["Products", "Products"],
+    ["Product Detail", "Product Detail"],
+    ["Cart", "Cart"],
+    ["Checkout", "Checkout"],
+    ["Orders", "Orders"],
+    ["My Page", "My Page"],
+    ["Admin", "Admin Dashboard"],
+    ["Admin Categories", "Admin Categories"],
+    ["Admin Products", "Admin Products"],
+    ["Admin Orders", "Admin Orders"],
+    ["Admin Reviews", "Admin Reviews"],
+  ] as const;
+
+  for (const [link, heading] of screens) {
+    await page.getByRole("link", { name: link, exact: true }).click();
+    await expect(page.locator("h1")).toHaveText(heading);
+  }
+});

--- a/Frontend/web-shop/package-lock.json
+++ b/Frontend/web-shop/package-lock.json
@@ -1,0 +1,3310 @@
+{
+  "name": "web-shop",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "web-shop",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tanstack/react-query": "^5.59.0",
+        "axios": "^1.7.7",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.28.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.59.1",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.0.1",
+        "@types/react": "^18.3.12",
+        "@types/react-dom": "^18.3.1",
+        "@vitejs/plugin-react": "^4.3.3",
+        "jsdom": "^25.0.1",
+        "typescript": "^5.6.3",
+        "vite": "^5.4.10",
+        "vitest": "^2.1.4"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.99.2.tgz",
+      "integrity": "sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.99.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.99.2.tgz",
+      "integrity": "sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.99.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.21",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.21.tgz",
+      "integrity": "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001790",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
+      "integrity": "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.344",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
+      "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.38",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
+      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/Frontend/web-shop/package.json
+++ b/Frontend/web-shop/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run tests/smoke.test.tsx",
+    "test:smoke": "playwright test"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.59.0",
@@ -17,6 +18,7 @@
     "react-router-dom": "^6.28.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.0.1",
     "@types/react": "^18.3.12",

--- a/Frontend/web-shop/playwright.config.ts
+++ b/Frontend/web-shop/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  use: {
+    baseURL: "http://127.0.0.1:3102",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "npm run dev -- --host 127.0.0.1 --port 3102",
+    url: "http://127.0.0.1:3102",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/Frontend/web-shop/src/app/styles.css
+++ b/Frontend/web-shop/src/app/styles.css
@@ -1,9 +1,136 @@
-* { box-sizing: border-box; }
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
-  font-family: "Segoe UI", sans-serif;
-  background: linear-gradient(180deg, #f6f2e8 0%, #fffaf2 100%);
-  color: #1f1a14;
+  background: #fff;
+  color: #111;
+  font-family: "Segoe UI", "Noto Sans KR", sans-serif;
 }
-a { color: inherit; text-decoration: none; }
-button { font: inherit; }
+
+a {
+  color: #111;
+  text-decoration: none;
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+  border: 1px solid #111;
+  background: #111;
+  color: #fff;
+  padding: 8px 12px;
+}
+
+button.secondary {
+  background: #fff;
+  color: #111;
+}
+
+input,
+textarea,
+select {
+  width: 100%;
+  border: 1px solid #999;
+  background: #fff;
+  color: #111;
+  padding: 8px 10px;
+}
+
+textarea {
+  min-height: 90px;
+  resize: vertical;
+}
+
+.page {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 28px 20px 56px;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 16px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #ddd;
+}
+
+.nav a {
+  font-size: 14px;
+  text-decoration: underline;
+}
+
+.header {
+  padding: 28px 0;
+}
+
+.eyebrow {
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.header h1 {
+  margin: 8px 0;
+  font-size: 34px;
+}
+
+.header p {
+  margin: 0;
+  color: #444;
+}
+
+.panel {
+  border: 1px solid #ddd;
+  padding: 20px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+}
+
+.card {
+  border: 1px solid #ddd;
+  padding: 16px;
+}
+
+.stack {
+  display: grid;
+  gap: 12px;
+}
+
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.muted {
+  color: #666;
+}
+
+.error {
+  color: #b00020;
+}
+
+.success {
+  color: #0b6b2b;
+}
+
+pre {
+  overflow: auto;
+  background: #f7f7f7;
+  border: 1px solid #ddd;
+  padding: 12px;
+}

--- a/Frontend/web-shop/src/entities/address/api.ts
+++ b/Frontend/web-shop/src/entities/address/api.ts
@@ -1,0 +1,11 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { Address } from "./model";
+
+export const fetchAddresses = () => unwrap<Address[]>(apiClient.get("/api/v1/addresses", { headers: authHeader("user") }));
+export const createAddress = (payload: Omit<Address, "id">) =>
+  unwrap<Address>(apiClient.post("/api/v1/addresses", payload, { headers: authHeader("user") }));
+export const updateAddress = (addressId: number, payload: Partial<Omit<Address, "id">>) =>
+  unwrap<Address>(apiClient.patch(`/api/v1/addresses/${addressId}`, payload, { headers: authHeader("user") }));
+export const deleteAddress = (addressId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/addresses/${addressId}`, { headers: authHeader("user") }));

--- a/Frontend/web-shop/src/entities/address/model.ts
+++ b/Frontend/web-shop/src/entities/address/model.ts
@@ -1,0 +1,9 @@
+export interface Address {
+  id: number;
+  recipientName: string;
+  phone: string;
+  zipCode: string;
+  address1: string;
+  address2: string;
+  isDefault: boolean;
+}

--- a/Frontend/web-shop/src/entities/admin/api.ts
+++ b/Frontend/web-shop/src/entities/admin/api.ts
@@ -1,0 +1,6 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { AdminDashboard } from "./model";
+
+export const fetchAdminDashboard = () =>
+  unwrap<AdminDashboard>(apiClient.get("/api/v1/admin/dashboard", { headers: authHeader("admin") }));

--- a/Frontend/web-shop/src/entities/admin/model.ts
+++ b/Frontend/web-shop/src/entities/admin/model.ts
@@ -1,0 +1,6 @@
+export interface AdminDashboard {
+  orderSummary: Record<string, number>;
+  productSummary: Record<string, number>;
+  userSummary: Record<string, number>;
+  reviewSummary: Record<string, number>;
+}

--- a/Frontend/web-shop/src/entities/cart/api.ts
+++ b/Frontend/web-shop/src/entities/cart/api.ts
@@ -1,0 +1,13 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { CartItem } from "./model";
+
+export const fetchCart = () => unwrap<CartItem[]>(apiClient.get("/api/v1/cart-items", { headers: authHeader("user") }));
+export const addCart = (payload: { productId: number; productOptionId?: number; quantity: number }) =>
+  unwrap<CartItem>(apiClient.post("/api/v1/cart-items", payload, { headers: authHeader("user") }));
+export const updateCart = (cartItemId: number, quantity: number) =>
+  unwrap<CartItem>(apiClient.patch(`/api/v1/cart-items/${cartItemId}`, { quantity }, { headers: authHeader("user") }));
+export const deleteCart = (cartItemId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/cart-items/${cartItemId}`, { headers: authHeader("user") }));
+export const clearCart = () =>
+  unwrap<{ message: string }>(apiClient.delete("/api/v1/cart-items", { headers: authHeader("user") }));

--- a/Frontend/web-shop/src/entities/cart/model.ts
+++ b/Frontend/web-shop/src/entities/cart/model.ts
@@ -1,0 +1,9 @@
+export interface CartItem {
+  id: number;
+  productId: number;
+  productOptionId?: number | null;
+  productName: string;
+  quantity: number;
+  unitPrice: number;
+  lineAmount: number;
+}

--- a/Frontend/web-shop/src/entities/category/api.ts
+++ b/Frontend/web-shop/src/entities/category/api.ts
@@ -1,0 +1,12 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { CategorySummary } from "./model";
+
+export const fetchCategories = () => unwrap<CategorySummary[]>(apiClient.get("/api/v1/categories"));
+export const fetchCategory = (categoryId: number) => unwrap<CategorySummary>(apiClient.get(`/api/v1/categories/${categoryId}`));
+export const createCategory = (payload: { name: string; displayOrder: number }) =>
+  unwrap<CategorySummary>(apiClient.post("/api/v1/admin/categories", payload, { headers: authHeader("admin") }));
+export const updateCategory = (categoryId: number, payload: Partial<CategorySummary>) =>
+  unwrap<CategorySummary>(apiClient.patch(`/api/v1/admin/categories/${categoryId}`, payload, { headers: authHeader("admin") }));
+export const deleteCategory = (categoryId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/admin/categories/${categoryId}`, { headers: authHeader("admin") }));

--- a/Frontend/web-shop/src/entities/category/model.ts
+++ b/Frontend/web-shop/src/entities/category/model.ts
@@ -1,0 +1,6 @@
+export interface CategorySummary {
+  id: number;
+  name: string;
+  displayOrder: number;
+  status: string;
+}

--- a/Frontend/web-shop/src/entities/order/api.ts
+++ b/Frontend/web-shop/src/entities/order/api.ts
@@ -1,0 +1,18 @@
+import { apiClient, unwrap, unwrapPaged } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { OrderDetail, OrderSummary } from "./model";
+
+export const createOrder = (payload: { cartItemIds: number[]; addressId: number }) =>
+  unwrap<OrderDetail>(apiClient.post("/api/v1/orders", payload, { headers: authHeader("user") }));
+export const fetchOrders = () =>
+  unwrapPaged<OrderSummary>(apiClient.get("/api/v1/orders", { headers: authHeader("user"), params: { page: 1, limit: 20 } }));
+export const fetchOrderDetail = (orderId: number) =>
+  unwrap<OrderDetail>(apiClient.get(`/api/v1/orders/${orderId}`, { headers: authHeader("user") }));
+export const cancelOrder = (orderId: number) =>
+  unwrap<OrderSummary>(apiClient.post(`/api/v1/orders/${orderId}/cancel`, null, { headers: authHeader("user") }));
+export const fetchAdminOrders = () =>
+  unwrapPaged<OrderSummary>(
+    apiClient.get("/api/v1/admin/orders", { headers: authHeader("admin"), params: { page: 1, limit: 20 } }),
+  );
+export const changeOrderStatus = (orderId: number, orderStatus: string) =>
+  unwrap<OrderSummary>(apiClient.patch(`/api/v1/admin/orders/${orderId}/status`, { orderStatus }, { headers: authHeader("admin") }));

--- a/Frontend/web-shop/src/entities/order/model.ts
+++ b/Frontend/web-shop/src/entities/order/model.ts
@@ -1,0 +1,16 @@
+import type { Address } from "../address/model";
+
+export interface OrderSummary {
+  id: number;
+  orderNumber: string;
+  orderStatus: string;
+  paymentStatus: string;
+  totalAmount: number;
+}
+
+export interface OrderDetail {
+  order: OrderSummary;
+  orderAddress: Address;
+  orderItems: Array<{ id: number; productId: number; productNameSnapshot: string; quantity: number; lineAmount: number }>;
+  payment: null | { id: number; paymentStatus: string; paidAmount: number };
+}

--- a/Frontend/web-shop/src/entities/payment/api.ts
+++ b/Frontend/web-shop/src/entities/payment/api.ts
@@ -1,0 +1,10 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { Payment } from "./model";
+
+export const createPayment = (orderId: number) =>
+  unwrap<Payment>(apiClient.post("/api/v1/payments", { orderId, paymentMethod: "mock" }, { headers: authHeader("user") }));
+export const fetchPayment = (paymentId: number) =>
+  unwrap<Payment>(apiClient.get(`/api/v1/payments/${paymentId}`, { headers: authHeader("user") }));
+export const refundPayment = (paymentId: number) =>
+  unwrap<Payment>(apiClient.post(`/api/v1/payments/${paymentId}/refund`, null, { headers: authHeader("user") }));

--- a/Frontend/web-shop/src/entities/payment/model.ts
+++ b/Frontend/web-shop/src/entities/payment/model.ts
@@ -1,0 +1,7 @@
+export interface Payment {
+  id: number;
+  orderId: number;
+  paymentMethod: string;
+  paymentStatus: string;
+  paidAmount: number;
+}

--- a/Frontend/web-shop/src/entities/product/api.ts
+++ b/Frontend/web-shop/src/entities/product/api.ts
@@ -1,0 +1,24 @@
+import { apiClient, unwrap, unwrapPaged } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { ProductDetail, ProductSummary } from "./model";
+
+export const fetchProducts = (params?: Record<string, string | number>) =>
+  unwrapPaged<ProductSummary>(apiClient.get("/api/v1/products", { params }));
+export const fetchProductDetail = (productId: number) =>
+  unwrap<ProductDetail>(apiClient.get(`/api/v1/products/${productId}`));
+export const createProduct = (payload: {
+  categoryId: number;
+  name: string;
+  description: string;
+  price: number;
+  stock: number;
+  status?: string;
+}) => unwrap<ProductDetail>(apiClient.post("/api/v1/admin/products", payload, { headers: authHeader("admin") }));
+export const updateProduct = (productId: number, payload: Partial<ProductSummary> & { description?: string }) =>
+  unwrap<ProductDetail>(apiClient.patch(`/api/v1/admin/products/${productId}`, payload, { headers: authHeader("admin") }));
+export const deleteProduct = (productId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/admin/products/${productId}`, { headers: authHeader("admin") }));
+export const createOption = (productId: number, payload: { name: string; value: string; additionalPrice: number; stock: number }) =>
+  unwrap(apiClient.post(`/api/v1/admin/products/${productId}/options`, payload, { headers: authHeader("admin") }));
+export const createImage = (productId: number, payload: { imageUrl: string; isPrimary: boolean; displayOrder: number }) =>
+  unwrap(apiClient.post(`/api/v1/admin/products/${productId}/images`, payload, { headers: authHeader("admin") }));

--- a/Frontend/web-shop/src/entities/product/model.ts
+++ b/Frontend/web-shop/src/entities/product/model.ts
@@ -1,0 +1,29 @@
+export interface ProductSummary {
+  id: number;
+  categoryId: number;
+  name: string;
+  price: number;
+  stock: number;
+  status: string;
+}
+
+export interface ProductOption {
+  id: number;
+  name: string;
+  value: string;
+  additionalPrice: number;
+  stock: number;
+}
+
+export interface ProductImage {
+  id: number;
+  imageUrl: string;
+  isPrimary: boolean;
+  displayOrder: number;
+}
+
+export interface ProductDetail extends ProductSummary {
+  description: string;
+  options: ProductOption[];
+  images: ProductImage[];
+}

--- a/Frontend/web-shop/src/entities/review/api.ts
+++ b/Frontend/web-shop/src/entities/review/api.ts
@@ -1,0 +1,16 @@
+import { apiClient, unwrap, unwrapPaged } from "../../shared/api/client";
+import { authHeader } from "../session/storage";
+import type { Review } from "./model";
+
+export const fetchProductReviews = (productId: number) =>
+  unwrapPaged<Review>(apiClient.get(`/api/v1/products/${productId}/reviews`, { params: { page: 1, limit: 20 } }));
+export const createReview = (orderItemId: number, payload: { rating: number; content: string }) =>
+  unwrap<Review>(apiClient.post(`/api/v1/order-items/${orderItemId}/reviews`, payload, { headers: authHeader("user") }));
+export const updateReview = (reviewId: number, payload: { rating: number; content: string }) =>
+  unwrap<Review>(apiClient.patch(`/api/v1/reviews/${reviewId}`, payload, { headers: authHeader("user") }));
+export const deleteReview = (reviewId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/reviews/${reviewId}`, { headers: authHeader("user") }));
+export const fetchAdminReviews = () =>
+  unwrapPaged<Review>(apiClient.get("/api/v1/admin/reviews", { headers: authHeader("admin"), params: { page: 1, limit: 20 } }));
+export const deleteAdminReview = (reviewId: number) =>
+  unwrap<{ message: string }>(apiClient.delete(`/api/v1/admin/reviews/${reviewId}`, { headers: authHeader("admin") }));

--- a/Frontend/web-shop/src/entities/review/model.ts
+++ b/Frontend/web-shop/src/entities/review/model.ts
@@ -1,0 +1,8 @@
+export interface Review {
+  id: number;
+  productId: number;
+  orderItemId: number;
+  rating: number;
+  content: string;
+  status: string;
+}

--- a/Frontend/web-shop/src/entities/session/api.ts
+++ b/Frontend/web-shop/src/entities/session/api.ts
@@ -1,0 +1,59 @@
+import { apiClient, unwrap } from "../../shared/api/client";
+import type { HealthPayload } from "../../shared/types";
+import type { AdminMe, TokenPair, UserMe } from "./model";
+import { authHeader, sessionStore } from "./storage";
+
+export const fetchHealth = () => unwrap<HealthPayload>(apiClient.get("/api/v1/health"));
+export const signupUser = (payload: { email: string; password: string; name: string; phone: string }) =>
+  unwrap<UserMe>(apiClient.post("/api/v1/auth/signup", payload));
+
+export async function loginUser(payload: { email: string; password: string }) {
+  const tokens = await unwrap<TokenPair>(apiClient.post("/api/v1/auth/login", payload));
+  sessionStore.saveUser(tokens);
+  return tokens;
+}
+
+export async function refreshUser() {
+  const tokens = await unwrap<TokenPair>(
+    apiClient.post("/api/v1/auth/refresh", { refreshToken: sessionStore.userRefresh() }),
+  );
+  sessionStore.saveUser(tokens);
+  return tokens;
+}
+
+export async function logoutUser() {
+  const result = await unwrap<{ message: string }>(
+    apiClient.post("/api/v1/auth/logout", null, { headers: authHeader("user") }),
+  );
+  sessionStore.clearUser();
+  return result;
+}
+
+export const fetchMe = () => unwrap<UserMe>(apiClient.get("/api/v1/users/me", { headers: authHeader("user") }));
+export const updateMe = (payload: { name: string; phone: string }) =>
+  unwrap<UserMe>(apiClient.patch("/api/v1/users/me", payload, { headers: authHeader("user") }));
+
+export async function loginAdmin(payload: { email: string; password: string }) {
+  const tokens = await unwrap<TokenPair>(apiClient.post("/api/v1/admin/auth/login", payload));
+  sessionStore.saveAdmin(tokens);
+  return tokens;
+}
+
+export async function refreshAdmin() {
+  const tokens = await unwrap<TokenPair>(
+    apiClient.post("/api/v1/admin/auth/refresh", { refreshToken: sessionStore.adminRefresh() }),
+  );
+  sessionStore.saveAdmin(tokens);
+  return tokens;
+}
+
+export async function logoutAdmin() {
+  const result = await unwrap<{ message: string }>(
+    apiClient.post("/api/v1/admin/auth/logout", null, { headers: authHeader("admin") }),
+  );
+  sessionStore.clearAdmin();
+  return result;
+}
+
+export const fetchAdminMe = () =>
+  unwrap<AdminMe>(apiClient.get("/api/v1/admin/me", { headers: authHeader("admin") }));

--- a/Frontend/web-shop/src/entities/session/model.ts
+++ b/Frontend/web-shop/src/entities/session/model.ts
@@ -1,0 +1,19 @@
+export interface TokenPair {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface UserMe {
+  id: number;
+  email: string;
+  name: string;
+  phone: string;
+  status: string;
+}
+
+export interface AdminMe {
+  id: number;
+  email: string;
+  name: string;
+  status: string;
+}

--- a/Frontend/web-shop/src/entities/session/storage.ts
+++ b/Frontend/web-shop/src/entities/session/storage.ts
@@ -1,0 +1,36 @@
+import type { TokenPair } from "./model";
+
+const userTokenKey = "web-shop-user-access-token";
+const userRefreshKey = "web-shop-user-refresh-token";
+const adminTokenKey = "web-shop-admin-access-token";
+const adminRefreshKey = "web-shop-admin-refresh-token";
+
+const read = (key: string) => window.localStorage.getItem(key) ?? "";
+const write = (key: string, value: string) => window.localStorage.setItem(key, value);
+const remove = (key: string) => window.localStorage.removeItem(key);
+
+export function authHeader(kind: "user" | "admin") {
+  const token = kind === "user" ? read(userTokenKey) : read(adminTokenKey);
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export const sessionStore = {
+  userRefresh: () => read(userRefreshKey),
+  adminRefresh: () => read(adminRefreshKey),
+  saveUser(tokens: TokenPair) {
+    write(userTokenKey, tokens.accessToken);
+    write(userRefreshKey, tokens.refreshToken);
+  },
+  saveAdmin(tokens: TokenPair) {
+    write(adminTokenKey, tokens.accessToken);
+    write(adminRefreshKey, tokens.refreshToken);
+  },
+  clearUser() {
+    remove(userTokenKey);
+    remove(userRefreshKey);
+  },
+  clearAdmin() {
+    remove(adminTokenKey);
+    remove(adminRefreshKey);
+  },
+};

--- a/Frontend/web-shop/src/features/address-manage/AddressActions.tsx
+++ b/Frontend/web-shop/src/features/address-manage/AddressActions.tsx
@@ -1,0 +1,42 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createAddress, deleteAddress, updateAddress } from "../../entities/address/api";
+
+export function CreateSampleAddressButton({ onCreated }: { onCreated?: (addressId: number) => void }) {
+  const queryClient = useQueryClient();
+  const create = useMutation({
+    mutationFn: () =>
+      createAddress({
+        recipientName: "Frontend Buyer",
+        phone: "01012345678",
+        zipCode: "12345",
+        address1: "Seoul simple road",
+        address2: "1F",
+        isDefault: true,
+      }),
+    onSuccess: (address) => {
+      onCreated?.(address.id);
+      queryClient.invalidateQueries({ queryKey: ["addresses"] });
+    },
+  });
+
+  return (
+    <button className="secondary" type="button" onClick={() => create.mutate()}>
+      Create sample address
+    </button>
+  );
+}
+
+export function AddressRowActions({ addressId }: { addressId: number }) {
+  const queryClient = useQueryClient();
+  const reload = () => queryClient.invalidateQueries({ queryKey: ["addresses"] });
+  return (
+    <>
+      <button type="button" onClick={() => updateAddress(addressId, { address2: "Updated" }).then(reload)}>
+        Quick update
+      </button>
+      <button className="secondary" type="button" onClick={() => deleteAddress(addressId).then(reload)}>
+        Delete
+      </button>
+    </>
+  );
+}

--- a/Frontend/web-shop/src/features/admin-category-manage/AdminCategoryManager.tsx
+++ b/Frontend/web-shop/src/features/admin-category-manage/AdminCategoryManager.tsx
@@ -1,0 +1,37 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createCategory, deleteCategory, updateCategory } from "../../entities/category/api";
+import type { CategorySummary } from "../../entities/category/model";
+
+export function AdminCategoryManager({ categories }: { categories: CategorySummary[] }) {
+  const queryClient = useQueryClient();
+  const [name, setName] = useState("frontend-category");
+  const [displayOrder, setDisplayOrder] = useState(10);
+  const reload = () => queryClient.invalidateQueries({ queryKey: ["categories"] });
+  const create = useMutation({ mutationFn: () => createCategory({ name, displayOrder }), onSuccess: reload });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    create.mutate();
+  }
+
+  return (
+    <>
+      <form className="row" onSubmit={submit}>
+        <input value={name} onChange={(event) => setName(event.target.value)} />
+        <input type="number" value={displayOrder} onChange={(event) => setDisplayOrder(Number(event.target.value))} />
+        <button type="submit">Create category</button>
+      </form>
+      <div className="stack">
+        {categories.map((category) => (
+          <div className="card row" key={category.id}>
+            <strong>#{category.id} {category.name}</strong>
+            <span>{category.status}</span>
+            <button type="button" onClick={() => updateCategory(category.id, { status: "HIDDEN" }).then(reload)}>Hide</button>
+            <button className="secondary" type="button" onClick={() => deleteCategory(category.id).then(reload)}>Delete</button>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-shop/src/features/admin-order-status/AdminOrderStatusActions.tsx
+++ b/Frontend/web-shop/src/features/admin-order-status/AdminOrderStatusActions.tsx
@@ -1,0 +1,20 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { changeOrderStatus } from "../../entities/order/api";
+import type { OrderSummary } from "../../entities/order/model";
+
+export function AdminOrderStatusActions({ orders }: { orders: OrderSummary[] }) {
+  const queryClient = useQueryClient();
+  const reload = () => queryClient.invalidateQueries({ queryKey: ["admin-orders"] });
+  return (
+    <div className="stack">
+      {orders.map((order) => (
+        <div className="card row" key={order.id}>
+          <strong>#{order.id} {order.orderNumber}</strong>
+          <span>{order.orderStatus}</span>
+          <button type="button" onClick={() => changeOrderStatus(order.id, "PREPARING").then(reload)}>Preparing</button>
+          <button className="secondary" type="button" onClick={() => changeOrderStatus(order.id, "SHIPPING").then(reload)}>Shipping</button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Frontend/web-shop/src/features/admin-product-manage/AdminProductManager.tsx
+++ b/Frontend/web-shop/src/features/admin-product-manage/AdminProductManager.tsx
@@ -1,0 +1,46 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createImage, createOption, createProduct, deleteProduct, updateProduct } from "../../entities/product/api";
+import type { ProductSummary } from "../../entities/product/model";
+
+export function AdminProductManager({ products }: { products: ProductSummary[] }) {
+  const queryClient = useQueryClient();
+  const [categoryId, setCategoryId] = useState(1);
+  const [name, setName] = useState("frontend-product");
+  const [price, setPrice] = useState(10000);
+  const reload = () => queryClient.invalidateQueries({ queryKey: ["products"] });
+  const create = useMutation({
+    mutationFn: () => createProduct({ categoryId, name, description: "Created in frontend", price, stock: 10, status: "ACTIVE" }),
+    onSuccess: reload,
+  });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    create.mutate();
+  }
+
+  return (
+    <>
+      <form className="grid" onSubmit={submit}>
+        <input type="number" value={categoryId} onChange={(event) => setCategoryId(Number(event.target.value))} />
+        <input value={name} onChange={(event) => setName(event.target.value)} />
+        <input type="number" value={price} onChange={(event) => setPrice(Number(event.target.value))} />
+        <button type="submit">Create product</button>
+      </form>
+      <div className="stack">
+        {products.map((product) => (
+          <div className="card stack" key={product.id}>
+            <strong>#{product.id} {product.name}</strong>
+            <span>{Number(product.price).toLocaleString()} KRW / {product.status}</span>
+            <div className="row">
+              <button type="button" onClick={() => updateProduct(product.id, { status: "HIDDEN" }).then(reload)}>Hide</button>
+              <button className="secondary" type="button" onClick={() => createOption(product.id, { name: "size", value: "basic", additionalPrice: 0, stock: 5 })}>Add option</button>
+              <button className="secondary" type="button" onClick={() => createImage(product.id, { imageUrl: "https://example.com/simple.jpg", isPrimary: false, displayOrder: 1 })}>Add image</button>
+              <button className="secondary" type="button" onClick={() => deleteProduct(product.id).then(reload)}>Delete</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-shop/src/features/admin-review-delete/AdminReviewDeleteActions.tsx
+++ b/Frontend/web-shop/src/features/admin-review-delete/AdminReviewDeleteActions.tsx
@@ -1,0 +1,20 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { deleteAdminReview } from "../../entities/review/api";
+import type { Review } from "../../entities/review/model";
+
+export function AdminReviewDeleteActions({ reviews }: { reviews: Review[] }) {
+  const queryClient = useQueryClient();
+  return (
+    <div className="stack">
+      {reviews.map((review) => (
+        <div className="card row" key={review.id}>
+          <span>#{review.id} rating {review.rating} / {review.content}</span>
+          <span>{review.status}</span>
+          <button className="secondary" type="button" onClick={() => deleteAdminReview(review.id).then(() => queryClient.invalidateQueries({ queryKey: ["admin-reviews"] }))}>
+            Delete
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/Frontend/web-shop/src/features/auth-admin/AdminLoginPanel.tsx
+++ b/Frontend/web-shop/src/features/auth-admin/AdminLoginPanel.tsx
@@ -1,0 +1,35 @@
+import { FormEvent, useState } from "react";
+import { loginAdmin, logoutAdmin, refreshAdmin } from "../../entities/session/api";
+
+export function AdminLoginPanel() {
+  const [email, setEmail] = useState("admin-shop-1@example.com");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setError("");
+    try {
+      await loginAdmin({ email, password: "AdminPassword1!" });
+      setMessage("Admin login saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Admin login failed");
+    }
+  }
+
+  return (
+    <form className="card stack" onSubmit={submit}>
+      <h2>Admin</h2>
+      <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      <button type="submit">Login admin</button>
+      <button className="secondary" type="button" onClick={() => refreshAdmin().then(() => setMessage("Admin token refreshed."))}>
+        Refresh admin
+      </button>
+      <button className="secondary" type="button" onClick={() => logoutAdmin().then(() => setMessage("Admin logged out."))}>
+        Logout admin
+      </button>
+      {message && <p className="success">{message}</p>}
+      {error && <p className="error">{error}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-shop/src/features/auth-user/UserLoginPanel.tsx
+++ b/Frontend/web-shop/src/features/auth-user/UserLoginPanel.tsx
@@ -1,0 +1,35 @@
+import { FormEvent, useState } from "react";
+import { loginUser, logoutUser, refreshUser } from "../../entities/session/api";
+
+export function UserLoginPanel() {
+  const [email, setEmail] = useState("shop-user-1@example.com");
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    setError("");
+    try {
+      await loginUser({ email, password: "Password1!" });
+      setMessage("User login saved.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "User login failed");
+    }
+  }
+
+  return (
+    <form className="card stack" onSubmit={submit}>
+      <h2>User</h2>
+      <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      <button type="submit">Login user</button>
+      <button className="secondary" type="button" onClick={() => refreshUser().then(() => setMessage("User token refreshed."))}>
+        Refresh user
+      </button>
+      <button className="secondary" type="button" onClick={() => logoutUser().then(() => setMessage("User logged out."))}>
+        Logout user
+      </button>
+      {message && <p className="success">{message}</p>}
+      {error && <p className="error">{error}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-shop/src/features/cart-add/AddCartButton.tsx
+++ b/Frontend/web-shop/src/features/cart-add/AddCartButton.tsx
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { addCart } from "../../entities/cart/api";
+
+interface Props {
+  productId: number;
+}
+
+export function AddCartButton({ productId }: Props) {
+  const queryClient = useQueryClient();
+  const cart = useMutation({
+    mutationFn: () => addCart({ productId, quantity: 1 }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["cart"] }),
+  });
+
+  return (
+    <>
+      <button type="button" onClick={() => cart.mutate()}>Add cart</button>
+      {cart.error && <p className="error">{cart.error.message}</p>}
+    </>
+  );
+}

--- a/Frontend/web-shop/src/features/cart-update/CartItemActions.tsx
+++ b/Frontend/web-shop/src/features/cart-update/CartItemActions.tsx
@@ -1,0 +1,26 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { clearCart, deleteCart, updateCart } from "../../entities/cart/api";
+
+export function useCartReload() {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: ["cart"] });
+}
+
+export function CartItemActions({ cartItemId, quantity }: { cartItemId: number; quantity: number }) {
+  const reload = useCartReload();
+  return (
+    <>
+      <button type="button" onClick={() => updateCart(cartItemId, quantity + 1).then(reload)}>+1</button>
+      <button className="secondary" type="button" onClick={() => deleteCart(cartItemId).then(reload)}>Delete</button>
+    </>
+  );
+}
+
+export function ClearCartButton() {
+  const reload = useCartReload();
+  return (
+    <button className="secondary" type="button" onClick={() => clearCart().then(reload)}>
+      Clear cart
+    </button>
+  );
+}

--- a/Frontend/web-shop/src/features/checkout-create-order/CreateOrderForm.tsx
+++ b/Frontend/web-shop/src/features/checkout-create-order/CreateOrderForm.tsx
@@ -1,0 +1,33 @@
+import { FormEvent, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { createOrder } from "../../entities/order/api";
+import type { CartItem } from "../../entities/cart/model";
+
+interface Props {
+  cartItems: CartItem[];
+  addressId: number;
+  onAddressChange: (addressId: number) => void;
+}
+
+export function CreateOrderForm({ cartItems, addressId, onAddressChange }: Props) {
+  const queryClient = useQueryClient();
+  const [result, setResult] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const order = await createOrder({ cartItemIds: cartItems.map((item) => item.id), addressId });
+    setResult(`Order #${order.order.id} created.`);
+    queryClient.invalidateQueries({ queryKey: ["cart"] });
+  }
+
+  return (
+    <form className="stack" onSubmit={submit}>
+      <label>
+        Address ID
+        <input type="number" value={addressId} onChange={(event) => onAddressChange(Number(event.target.value))} />
+      </label>
+      <button type="submit">Create order</button>
+      {result && <p className="success">{result}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-shop/src/features/payment-create/PaymentActions.tsx
+++ b/Frontend/web-shop/src/features/payment-create/PaymentActions.tsx
@@ -1,0 +1,25 @@
+import { FormEvent } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createPayment } from "../../entities/payment/api";
+
+export function CreatePaymentForm({ orderId, onPaid }: { orderId: number; onPaid: (paymentId: number) => void }) {
+  const queryClient = useQueryClient();
+  const createPay = useMutation({
+    mutationFn: () => createPayment(orderId),
+    onSuccess: (result) => {
+      onPaid(result.id);
+      queryClient.invalidateQueries({ queryKey: ["order-detail", orderId] });
+    },
+  });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    createPay.mutate();
+  }
+
+  return (
+    <form className="row" onSubmit={submit}>
+      <button type="submit">Pay order</button>
+    </form>
+  );
+}

--- a/Frontend/web-shop/src/features/payment-refund/RefundPaymentButton.tsx
+++ b/Frontend/web-shop/src/features/payment-refund/RefundPaymentButton.tsx
@@ -1,0 +1,11 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { refundPayment } from "../../entities/payment/api";
+
+export function RefundPaymentButton({ paymentId }: { paymentId: number }) {
+  const queryClient = useQueryClient();
+  return (
+    <button className="secondary" type="button" onClick={() => refundPayment(paymentId).then(() => queryClient.invalidateQueries({ queryKey: ["payment", paymentId] }))}>
+      Refund
+    </button>
+  );
+}

--- a/Frontend/web-shop/src/features/review-create/CreateReviewForm.tsx
+++ b/Frontend/web-shop/src/features/review-create/CreateReviewForm.tsx
@@ -1,0 +1,28 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createReview } from "../../entities/review/api";
+
+export function CreateReviewForm({ productId }: { productId: number }) {
+  const queryClient = useQueryClient();
+  const [orderItemId, setOrderItemId] = useState(1);
+  const [content, setContent] = useState("Good product");
+  const review = useMutation({
+    mutationFn: () => createReview(orderItemId, { rating: 5, content }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["reviews", productId] }),
+  });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    review.mutate();
+  }
+
+  return (
+    <form className="stack" onSubmit={submit}>
+      <h2>Create review</h2>
+      <input type="number" value={orderItemId} onChange={(event) => setOrderItemId(Number(event.target.value))} />
+      <textarea value={content} onChange={(event) => setContent(event.target.value)} />
+      <button type="submit">Create review</button>
+      {review.error && <p className="error">{review.error.message}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-shop/src/features/review-update/UpdateReviewButton.tsx
+++ b/Frontend/web-shop/src/features/review-update/UpdateReviewButton.tsx
@@ -1,0 +1,15 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { updateReview } from "../../entities/review/api";
+
+export function UpdateReviewButton({ reviewId, productId, content }: { reviewId: number; productId: number; content: string }) {
+  const queryClient = useQueryClient();
+  return (
+    <button
+      className="secondary"
+      type="button"
+      onClick={() => updateReview(reviewId, { rating: 4, content: `${content} updated` }).then(() => queryClient.invalidateQueries({ queryKey: ["reviews", productId] }))}
+    >
+      Quick update
+    </button>
+  );
+}

--- a/Frontend/web-shop/src/features/signup-user/SignupUserForm.tsx
+++ b/Frontend/web-shop/src/features/signup-user/SignupUserForm.tsx
@@ -1,0 +1,25 @@
+import { FormEvent, useState } from "react";
+import { signupUser } from "../../entities/session/api";
+
+export function SignupUserForm() {
+  const [email, setEmail] = useState(`shop-${Date.now()}@example.com`);
+  const [name, setName] = useState("New Customer");
+  const [phone, setPhone] = useState("01012345678");
+  const [result, setResult] = useState("");
+
+  async function submit(event: FormEvent) {
+    event.preventDefault();
+    const user = await signupUser({ email, name, phone, password: "Password1!" });
+    setResult(`Created user #${user.id} ${user.email}`);
+  }
+
+  return (
+    <form className="stack" onSubmit={submit}>
+      <input value={email} onChange={(event) => setEmail(event.target.value)} />
+      <input value={name} onChange={(event) => setName(event.target.value)} />
+      <input value={phone} onChange={(event) => setPhone(event.target.value)} />
+      <button type="submit">Create user</button>
+      {result && <p className="success">{result}</p>}
+    </form>
+  );
+}

--- a/Frontend/web-shop/src/pages/admin-categories/page.tsx
+++ b/Frontend/web-shop/src/pages/admin-categories/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminCategoryPanel } from "../../widgets/admin-category-panel/AdminCategoryPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminCategoriesPage() {
-  return <PageShell title="Admin Categories" description="web-shop::admin-categories" />;
+  return (
+    <PageShell title="Admin Categories" description="카테고리 CRUD입니다.">
+      <AdminCategoryPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/admin-dashboard/page.tsx
+++ b/Frontend/web-shop/src/pages/admin-dashboard/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminDashboardPanel } from "../../widgets/admin-dashboard-panel/AdminDashboardPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminDashboardPage() {
-  return <PageShell title="Admin Dashboard" description="web-shop::admin-dashboard" />;
+  return (
+    <PageShell title="Admin Dashboard" description="관리자 계정과 쇼핑몰 운영 요약입니다.">
+      <AdminDashboardPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/admin-orders/page.tsx
+++ b/Frontend/web-shop/src/pages/admin-orders/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminOrderPanel } from "../../widgets/admin-order-panel/AdminOrderPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminOrdersPage() {
-  return <PageShell title="Admin Orders" description="web-shop::admin-orders" />;
+  return (
+    <PageShell title="Admin Orders" description="주문 상태를 운영합니다.">
+      <AdminOrderPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/admin-products/page.tsx
+++ b/Frontend/web-shop/src/pages/admin-products/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminProductPanel } from "../../widgets/admin-product-panel/AdminProductPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminProductsPage() {
-  return <PageShell title="Admin Products" description="web-shop::admin-products" />;
+  return (
+    <PageShell title="Admin Products" description="상품, 옵션, 이미지를 관리합니다.">
+      <AdminProductPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/admin-reviews/page.tsx
+++ b/Frontend/web-shop/src/pages/admin-reviews/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { AdminReviewPanel } from "../../widgets/admin-review-panel/AdminReviewPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function AdminReviewsPage() {
-  return <PageShell title="Admin Reviews" description="web-shop::admin-reviews" />;
+  return (
+    <PageShell title="Admin Reviews" description="리뷰를 조회하고 삭제합니다.">
+      <AdminReviewPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/cart/page.tsx
+++ b/Frontend/web-shop/src/pages/cart/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { CartPanel } from "../../widgets/cart-panel/CartPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function CartPage() {
-  return <PageShell title="Cart" description="web-shop::cart" />;
+  return (
+    <PageShell title="Cart" description="장바구니 항목을 확인하고 수량을 변경합니다.">
+      <CartPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/checkout/page.tsx
+++ b/Frontend/web-shop/src/pages/checkout/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { CheckoutPanel } from "../../widgets/checkout-panel/CheckoutPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function CheckoutPage() {
-  return <PageShell title="Checkout" description="web-shop::checkout" />;
+  return (
+    <PageShell title="Checkout" description="장바구니 항목과 배송지로 주문을 생성합니다.">
+      <CheckoutPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/home/page.tsx
+++ b/Frontend/web-shop/src/pages/home/page.tsx
@@ -1,1 +1,10 @@
-import { useQuery } from "@tanstack/react-query"; import { fetchHealth } from "../../shared/api/client"; import { PageShell } from "../../shared/ui/PageShell"; export function HomePage() { const { data, isLoading } = useQuery({ queryKey: ["health"], queryFn: fetchHealth }); return (<PageShell title="Home" description="web-shop::home"><p>API Base: {import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000"}</p><p>{isLoading ? "Loading health..." : `Status: ${data?.status} / ${data?.service}`}</p></PageShell>); }
+import { HomeSummary } from "../../widgets/home-summary/HomeSummary";
+import { PageShell } from "../../widgets/app-shell/PageShell";
+
+export function HomePage() {
+  return (
+    <PageShell title="Shop Home" description="쇼핑몰 API 상태와 주요 상품을 확인합니다.">
+      <HomeSummary />
+    </PageShell>
+  );
+}

--- a/Frontend/web-shop/src/pages/login/page.tsx
+++ b/Frontend/web-shop/src/pages/login/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { LoginPanel } from "../../widgets/app-shell/LoginPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function LoginPage() {
-  return <PageShell title="Login" description="web-shop::login" />;
+  return (
+    <PageShell title="Login" description="사용자와 관리자를 분리해서 로그인합니다.">
+      <LoginPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/mypage/page.tsx
+++ b/Frontend/web-shop/src/pages/mypage/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { MypagePanel } from "../../widgets/mypage-panel/MypagePanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function MypagePage() {
-  return <PageShell title="My Page" description="web-shop::mypage" />;
+  return (
+    <PageShell title="My Page" description="회원 정보와 배송지를 확인합니다.">
+      <MypagePanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/orders/page.tsx
+++ b/Frontend/web-shop/src/pages/orders/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { OrdersPanel } from "../../widgets/orders-panel/OrdersPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function OrdersPage() {
-  return <PageShell title="Orders" description="web-shop::orders" />;
+  return (
+    <PageShell title="Orders" description="주문 상세, 결제, 환불, 취소를 확인합니다.">
+      <OrdersPanel />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/pages/product-detail/page.tsx
+++ b/Frontend/web-shop/src/pages/product-detail/page.tsx
@@ -1,1 +1,10 @@
-import { useQuery } from "@tanstack/react-query"; import { fetchProductDetail } from "../../shared/api/client"; import { PageShell } from "../../shared/ui/PageShell"; export function ProductDetailPage() { const query = useQuery({ queryKey: ["product-detail", 1], queryFn: () => fetchProductDetail(1) }); return (<PageShell title="Product Detail" description="web-shop::product-detail"><pre>{JSON.stringify(query.data ?? { message: "Loading..." }, null, 2)}</pre></PageShell>); }
+import { ProductDetailPanel } from "../../widgets/product-detail-panel/ProductDetailPanel";
+import { PageShell } from "../../widgets/app-shell/PageShell";
+
+export function ProductDetailPage() {
+  return (
+    <PageShell title="Product Detail" description="상품 상세, 옵션/이미지, 리뷰를 확인합니다.">
+      <ProductDetailPanel />
+    </PageShell>
+  );
+}

--- a/Frontend/web-shop/src/pages/products/page.tsx
+++ b/Frontend/web-shop/src/pages/products/page.tsx
@@ -1,1 +1,10 @@
-import { useQuery } from "@tanstack/react-query"; import { fetchCategories, fetchProducts } from "../../shared/api/client"; import { PageShell } from "../../shared/ui/PageShell"; export function ProductsPage() { const categories = useQuery({ queryKey: ["categories"], queryFn: fetchCategories }); const products = useQuery({ queryKey: ["products"], queryFn: fetchProducts }); return (<PageShell title="Products" description="web-shop::products"><h2>Categories</h2><ul>{(categories.data ?? []).map((item) => (<li key={item.id}>{item.name} / {item.status}</li>))}</ul><h2>Products</h2><ul>{(products.data ?? []).map((item) => (<li key={item.id}>{item.name} / {item.price}</li>))}</ul></PageShell>); }
+import { ProductCatalog } from "../../widgets/product-catalog/ProductCatalog";
+import { PageShell } from "../../widgets/app-shell/PageShell";
+
+export function ProductsPage() {
+  return (
+    <PageShell title="Products" description="카테고리와 상품 목록을 확인하고 장바구니에 담습니다.">
+      <ProductCatalog />
+    </PageShell>
+  );
+}

--- a/Frontend/web-shop/src/pages/signup/page.tsx
+++ b/Frontend/web-shop/src/pages/signup/page.tsx
@@ -1,5 +1,10 @@
-import { PageShell } from "../../shared/ui/PageShell";
+import { SignupUserForm } from "../../features/signup-user/SignupUserForm";
+import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function SignupPage() {
-  return <PageShell title="Signup" description="web-shop::signup" />;
+  return (
+    <PageShell title="Signup" description="쇼핑몰 사용자 계정을 생성합니다.">
+      <SignupUserForm />
+    </PageShell>
+  );
 }

--- a/Frontend/web-shop/src/shared/api/client.ts
+++ b/Frontend/web-shop/src/shared/api/client.ts
@@ -1,1 +1,21 @@
-import axios from "axios"; import { env } from "../config/env"; import type { ApiEnvelope, CategorySummary, HealthPayload, ProductDetail, ProductSummary } from "../types"; export const apiClient = axios.create({ baseURL: env.apiBaseUrl, timeout: 5000 }); async function unwrap<T>(request: Promise<{ data: ApiEnvelope<T> }>) { const response = await request; if (!response.data.success || response.data.data === null) throw new Error(response.data.error?.message ?? "Request failed"); return response.data.data; } export const fetchHealth = () => unwrap<HealthPayload>(apiClient.get("/api/v1/health")); export const fetchCategories = () => unwrap<CategorySummary[]>(apiClient.get("/api/v1/categories")); export const fetchProducts = () => unwrap<ProductSummary[]>(apiClient.get("/api/v1/products")); export const fetchProductDetail = (productId: number) => unwrap<ProductDetail>(apiClient.get(`/api/v1/products/${productId}`));
+import axios from "axios";
+import { env } from "../config/env";
+import type { ApiEnvelope, PagedResult, PageMeta } from "../types";
+
+export const apiClient = axios.create({ baseURL: env.apiBaseUrl, timeout: 8000 });
+
+export async function unwrap<T>(request: Promise<{ data: ApiEnvelope<T> }>) {
+  const response = await request;
+  if (!response.data.success || response.data.data === null) {
+    throw new Error(response.data.error?.message ?? "Request failed");
+  }
+  return response.data.data;
+}
+
+export async function unwrapPaged<T>(request: Promise<{ data: ApiEnvelope<T[]> }>): Promise<PagedResult<T>> {
+  const response = await request;
+  if (!response.data.success || response.data.data === null) {
+    throw new Error(response.data.error?.message ?? "Request failed");
+  }
+  return { data: response.data.data, meta: (response.data.meta as PageMeta | undefined) ?? null };
+}

--- a/Frontend/web-shop/src/shared/types/index.ts
+++ b/Frontend/web-shop/src/shared/types/index.ts
@@ -1,8 +1,24 @@
-export interface ApiEnvelope<T> { success: boolean; data: T | null; meta?: Record<string, unknown> | null; error?: { code: string; message: string; details?: unknown } | null; }
-export interface HealthPayload { status: string; service: string; domain: string; }
-export interface BoardSummary { id: number; name: string; description: string; displayOrder: number; status: string; }
-export interface PostSummary { id: number; boardId: number; title: string; viewCount: number; likeCount: number; commentCount: number; status: string; }
-export interface PostDetail extends PostSummary { content: string; }
-export interface CategorySummary { id: number; name: string; displayOrder: number; status: string; }
-export interface ProductSummary { id: number; categoryId: number; name: string; price: number; stock: number; status: string; }
-export interface ProductDetail extends ProductSummary { description: string; }
+export interface ApiEnvelope<T> {
+  success: boolean;
+  data: T | null;
+  meta?: PageMeta | null;
+  error?: { code: string; message: string; details?: unknown } | null;
+}
+
+export interface PageMeta {
+  page: number;
+  limit: number;
+  totalCount: number;
+  totalPages: number;
+}
+
+export interface PagedResult<T> {
+  data: T[];
+  meta: PageMeta | null;
+}
+
+export interface HealthPayload {
+  status: string;
+  service: string;
+  domain: string;
+}

--- a/Frontend/web-shop/src/shared/ui/PageShell.tsx
+++ b/Frontend/web-shop/src/shared/ui/PageShell.tsx
@@ -1,3 +1,0 @@
-import { PropsWithChildren } from "react";
-interface Props extends PropsWithChildren { title: string; description: string; }
-export function PageShell({ title, description, children }: Props) { return (<main style={{ maxWidth: 1080, margin: "0 auto", padding: "48px 24px" }}><header style={{ marginBottom: 24 }}><div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 1.2, color: "#7a5d3a" }}>Project-Bible</div><h1 style={{ margin: "8px 0 0", fontSize: 36 }}>{title}</h1><p style={{ color: "#5d5144" }}>{description}</p></header><section style={{ padding: 24, borderRadius: 20, background: "#fff", border: "1px solid #eadcc7" }}>{children ?? <p>Baseline page is ready.</p>}</section></main>); }

--- a/Frontend/web-shop/src/widgets/admin-category-panel/AdminCategoryPanel.tsx
+++ b/Frontend/web-shop/src/widgets/admin-category-panel/AdminCategoryPanel.tsx
@@ -1,0 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchCategories } from "../../entities/category/api";
+import { AdminCategoryManager } from "../../features/admin-category-manage/AdminCategoryManager";
+
+export function AdminCategoryPanel() {
+  const categories = useQuery({ queryKey: ["categories", "admin"], queryFn: fetchCategories });
+  return <AdminCategoryManager categories={categories.data ?? []} />;
+}

--- a/Frontend/web-shop/src/widgets/admin-dashboard-panel/AdminDashboardPanel.tsx
+++ b/Frontend/web-shop/src/widgets/admin-dashboard-panel/AdminDashboardPanel.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminDashboard } from "../../entities/admin/api";
+import { fetchAdminMe } from "../../entities/session/api";
+
+export function AdminDashboardPanel() {
+  const me = useQuery({ queryKey: ["admin-me"], queryFn: fetchAdminMe, retry: false });
+  const dashboard = useQuery({ queryKey: ["admin-dashboard"], queryFn: fetchAdminDashboard, retry: false });
+
+  return (
+    <>
+      {me.error && <p className="error">Login as admin first.</p>}
+      {me.data && <p>Admin: {me.data.email}</p>}
+      {dashboard.data && <pre>{JSON.stringify(dashboard.data, null, 2)}</pre>}
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/admin-order-panel/AdminOrderPanel.tsx
+++ b/Frontend/web-shop/src/widgets/admin-order-panel/AdminOrderPanel.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminOrders } from "../../entities/order/api";
+import { AdminOrderStatusActions } from "../../features/admin-order-status/AdminOrderStatusActions";
+
+export function AdminOrderPanel() {
+  const orders = useQuery({ queryKey: ["admin-orders"], queryFn: fetchAdminOrders, retry: false });
+  return (
+    <>
+      <p className="muted">Total: {orders.data?.meta?.totalCount ?? 0}</p>
+      <AdminOrderStatusActions orders={orders.data?.data ?? []} />
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/admin-product-panel/AdminProductPanel.tsx
+++ b/Frontend/web-shop/src/widgets/admin-product-panel/AdminProductPanel.tsx
@@ -1,0 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchProducts } from "../../entities/product/api";
+import { AdminProductManager } from "../../features/admin-product-manage/AdminProductManager";
+
+export function AdminProductPanel() {
+  const products = useQuery({ queryKey: ["products", "admin"], queryFn: () => fetchProducts({ page: 1, limit: 20 }) });
+  return <AdminProductManager products={products.data?.data ?? []} />;
+}

--- a/Frontend/web-shop/src/widgets/admin-review-panel/AdminReviewPanel.tsx
+++ b/Frontend/web-shop/src/widgets/admin-review-panel/AdminReviewPanel.tsx
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchAdminReviews } from "../../entities/review/api";
+import { AdminReviewDeleteActions } from "../../features/admin-review-delete/AdminReviewDeleteActions";
+
+export function AdminReviewPanel() {
+  const reviews = useQuery({ queryKey: ["admin-reviews"], queryFn: fetchAdminReviews, retry: false });
+  return (
+    <>
+      <p className="muted">Total: {reviews.data?.meta?.totalCount ?? 0}</p>
+      <AdminReviewDeleteActions reviews={reviews.data?.data ?? []} />
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/app-shell/LoginPanel.tsx
+++ b/Frontend/web-shop/src/widgets/app-shell/LoginPanel.tsx
@@ -1,0 +1,11 @@
+import { AdminLoginPanel } from "../../features/auth-admin/AdminLoginPanel";
+import { UserLoginPanel } from "../../features/auth-user/UserLoginPanel";
+
+export function LoginPanel() {
+  return (
+    <div className="grid">
+      <UserLoginPanel />
+      <AdminLoginPanel />
+    </div>
+  );
+}

--- a/Frontend/web-shop/src/widgets/app-shell/PageShell.tsx
+++ b/Frontend/web-shop/src/widgets/app-shell/PageShell.tsx
@@ -1,0 +1,44 @@
+import { PropsWithChildren } from "react";
+import { Link } from "react-router-dom";
+
+interface Props extends PropsWithChildren {
+  title: string;
+  description: string;
+}
+
+const links = [
+  ["/", "Home"],
+  ["/login", "Login"],
+  ["/signup", "Signup"],
+  ["/products", "Products"],
+  ["/product-detail", "Product Detail"],
+  ["/cart", "Cart"],
+  ["/checkout", "Checkout"],
+  ["/orders", "Orders"],
+  ["/mypage", "My Page"],
+  ["/admin-dashboard", "Admin"],
+  ["/admin-categories", "Admin Categories"],
+  ["/admin-products", "Admin Products"],
+  ["/admin-orders", "Admin Orders"],
+  ["/admin-reviews", "Admin Reviews"],
+];
+
+export function PageShell({ title, description, children }: Props) {
+  return (
+    <main className="page">
+      <nav className="nav">
+        {links.map(([to, label]) => (
+          <Link key={to} to={to}>
+            {label}
+          </Link>
+        ))}
+      </nav>
+      <header className="header">
+        <div className="eyebrow">Project-Bible Shop</div>
+        <h1>{title}</h1>
+        <p>{description}</p>
+      </header>
+      <section className="panel">{children}</section>
+    </main>
+  );
+}

--- a/Frontend/web-shop/src/widgets/cart-panel/CartPanel.tsx
+++ b/Frontend/web-shop/src/widgets/cart-panel/CartPanel.tsx
@@ -1,0 +1,24 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchCart } from "../../entities/cart/api";
+import { CartItemActions, ClearCartButton } from "../../features/cart-update/CartItemActions";
+
+export function CartPanel() {
+  const cart = useQuery({ queryKey: ["cart"], queryFn: fetchCart, retry: false });
+
+  return (
+    <>
+      {cart.error && <p className="error">Login as user first.</p>}
+      <ClearCartButton />
+      <div className="stack">
+        {(cart.data ?? []).map((item) => (
+          <div className="card row" key={item.id}>
+            <strong>{item.productName}</strong>
+            <span>qty {item.quantity}</span>
+            <span>{Number(item.lineAmount).toLocaleString()} KRW</span>
+            <CartItemActions cartItemId={item.id} quantity={item.quantity} />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/checkout-panel/CheckoutPanel.tsx
+++ b/Frontend/web-shop/src/widgets/checkout-panel/CheckoutPanel.tsx
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchAddresses } from "../../entities/address/api";
+import { fetchCart } from "../../entities/cart/api";
+import { CreateSampleAddressButton } from "../../features/address-manage/AddressActions";
+import { CreateOrderForm } from "../../features/checkout-create-order/CreateOrderForm";
+
+export function CheckoutPanel() {
+  const cart = useQuery({ queryKey: ["cart", "checkout"], queryFn: fetchCart, retry: false });
+  const addresses = useQuery({ queryKey: ["addresses"], queryFn: fetchAddresses, retry: false });
+  const [addressId, setAddressId] = useState(1);
+
+  return (
+    <>
+      <div className="grid">
+        <div className="card">
+          <h2>Cart item IDs</h2>
+          <p>{(cart.data ?? []).map((item) => item.id).join(", ") || "No cart items"}</p>
+        </div>
+        <div className="card">
+          <h2>Addresses</h2>
+          {(addresses.data ?? []).map((address) => (
+            <p key={address.id}>#{address.id} {address.address1}</p>
+          ))}
+          <CreateSampleAddressButton onCreated={setAddressId} />
+        </div>
+      </div>
+      <CreateOrderForm cartItems={cart.data ?? []} addressId={addressId} onAddressChange={setAddressId} />
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/home-summary/HomeSummary.tsx
+++ b/Frontend/web-shop/src/widgets/home-summary/HomeSummary.tsx
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchProducts } from "../../entities/product/api";
+import { fetchHealth } from "../../entities/session/api";
+import { env } from "../../shared/config/env";
+
+export function HomeSummary() {
+  const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
+  const products = useQuery({ queryKey: ["products", "home"], queryFn: () => fetchProducts({ page: 1, limit: 5 }) });
+
+  return (
+    <>
+      <div className="grid">
+        <div className="card">
+          <h2>API</h2>
+          <p className="muted">{env.apiBaseUrl}</p>
+          <p>{health.isLoading ? "Checking..." : `${health.data?.status} / ${health.data?.service}`}</p>
+        </div>
+        <div className="card">
+          <h2>Products</h2>
+          <p>{products.data?.meta?.totalCount ?? 0} total products</p>
+        </div>
+      </div>
+      <h2>Featured</h2>
+      <div className="stack">
+        {(products.data?.data ?? []).map((product) => (
+          <div className="card" key={product.id}>
+            <strong>{product.name}</strong>
+            <p className="muted">{Number(product.price).toLocaleString()} KRW / stock {product.stock}</p>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/mypage-panel/MypagePanel.tsx
+++ b/Frontend/web-shop/src/widgets/mypage-panel/MypagePanel.tsx
@@ -1,0 +1,40 @@
+import { FormEvent, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { fetchAddresses } from "../../entities/address/api";
+import { fetchMe, updateMe } from "../../entities/session/api";
+import { AddressRowActions } from "../../features/address-manage/AddressActions";
+
+export function MypagePanel() {
+  const queryClient = useQueryClient();
+  const me = useQuery({ queryKey: ["me"], queryFn: fetchMe, retry: false });
+  const addresses = useQuery({ queryKey: ["addresses", "mypage"], queryFn: fetchAddresses, retry: false });
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("01012345678");
+  const update = useMutation({ mutationFn: () => updateMe({ name, phone }), onSuccess: () => queryClient.invalidateQueries({ queryKey: ["me"] }) });
+
+  function submit(event: FormEvent) {
+    event.preventDefault();
+    update.mutate();
+  }
+
+  return (
+    <>
+      {me.error && <p className="error">Login as user first.</p>}
+      {me.data && <pre>{JSON.stringify(me.data, null, 2)}</pre>}
+      <form className="row" onSubmit={submit}>
+        <input placeholder="Name" value={name} onChange={(event) => setName(event.target.value)} />
+        <input placeholder="Phone" value={phone} onChange={(event) => setPhone(event.target.value)} />
+        <button type="submit">Update me</button>
+      </form>
+      <h2>Addresses</h2>
+      <div className="stack">
+        {(addresses.data ?? []).map((address) => (
+          <div className="card row" key={address.id}>
+            <span>#{address.id} {address.address1} {address.address2}</span>
+            <AddressRowActions addressId={address.id} />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/orders-panel/OrdersPanel.tsx
+++ b/Frontend/web-shop/src/widgets/orders-panel/OrdersPanel.tsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { cancelOrder, fetchOrderDetail, fetchOrders } from "../../entities/order/api";
+import { fetchPayment } from "../../entities/payment/api";
+import { CreatePaymentForm } from "../../features/payment-create/PaymentActions";
+import { RefundPaymentButton } from "../../features/payment-refund/RefundPaymentButton";
+
+export function OrdersPanel() {
+  const queryClient = useQueryClient();
+  const orders = useQuery({ queryKey: ["orders"], queryFn: fetchOrders, retry: false });
+  const [orderId, setOrderId] = useState(1);
+  const [paymentId, setPaymentId] = useState(1);
+  const detail = useQuery({ queryKey: ["order-detail", orderId], queryFn: () => fetchOrderDetail(orderId), retry: false });
+  const payment = useQuery({ queryKey: ["payment", paymentId], queryFn: () => fetchPayment(paymentId), retry: false });
+
+  return (
+    <>
+      {orders.error && <p className="error">Login as user first.</p>}
+      <h2>Orders</h2>
+      <div className="stack">
+        {(orders.data?.data ?? []).map((order) => (
+          <button className="secondary" key={order.id} type="button" onClick={() => setOrderId(order.id)}>
+            #{order.id} {order.orderStatus} / {Number(order.totalAmount).toLocaleString()} KRW
+          </button>
+        ))}
+      </div>
+      <div className="row">
+        <input type="number" value={orderId} onChange={(event) => setOrderId(Number(event.target.value))} />
+        <CreatePaymentForm orderId={orderId} onPaid={setPaymentId} />
+        <button className="secondary" type="button" onClick={() => cancelOrder(orderId).then(() => queryClient.invalidateQueries({ queryKey: ["orders"] }))}>
+          Cancel order
+        </button>
+      </div>
+      {detail.data && <pre>{JSON.stringify(detail.data, null, 2)}</pre>}
+      <h2>Payment</h2>
+      <div className="row">
+        <input type="number" value={paymentId} onChange={(event) => setPaymentId(Number(event.target.value))} />
+        <RefundPaymentButton paymentId={paymentId} />
+      </div>
+      {payment.data && <pre>{JSON.stringify(payment.data, null, 2)}</pre>}
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/product-catalog/ProductCatalog.tsx
+++ b/Frontend/web-shop/src/widgets/product-catalog/ProductCatalog.tsx
@@ -1,0 +1,31 @@
+import { useQuery } from "@tanstack/react-query";
+import { fetchCategories } from "../../entities/category/api";
+import { fetchProducts } from "../../entities/product/api";
+import { AddCartButton } from "../../features/cart-add/AddCartButton";
+
+export function ProductCatalog() {
+  const categories = useQuery({ queryKey: ["categories"], queryFn: fetchCategories });
+  const products = useQuery({ queryKey: ["products"], queryFn: () => fetchProducts({ page: 1, limit: 20, sort: "latest" }) });
+
+  return (
+    <>
+      <h2>Categories</h2>
+      <div className="row">
+        {(categories.data ?? []).map((category) => (
+          <span className="card" key={category.id}>{category.name} / {category.status}</span>
+        ))}
+      </div>
+      <h2>Products</h2>
+      <div className="grid">
+        {(products.data?.data ?? []).map((product) => (
+          <div className="card stack" key={product.id}>
+            <strong>#{product.id} {product.name}</strong>
+            <span>{Number(product.price).toLocaleString()} KRW</span>
+            <span className="muted">stock {product.stock} / {product.status}</span>
+            <AddCartButton productId={product.id} />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/Frontend/web-shop/src/widgets/product-detail-panel/ProductDetailPanel.tsx
+++ b/Frontend/web-shop/src/widgets/product-detail-panel/ProductDetailPanel.tsx
@@ -1,0 +1,44 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchProductDetail } from "../../entities/product/api";
+import { fetchProductReviews } from "../../entities/review/api";
+import { AddCartButton } from "../../features/cart-add/AddCartButton";
+import { CreateReviewForm } from "../../features/review-create/CreateReviewForm";
+import { UpdateReviewButton } from "../../features/review-update/UpdateReviewButton";
+
+export function ProductDetailPanel() {
+  const [productId, setProductId] = useState(1);
+  const detail = useQuery({ queryKey: ["product-detail", productId], queryFn: () => fetchProductDetail(productId) });
+  const reviews = useQuery({ queryKey: ["reviews", productId], queryFn: () => fetchProductReviews(productId) });
+
+  return (
+    <>
+      <label>
+        Product ID
+        <input type="number" value={productId} onChange={(event) => setProductId(Number(event.target.value))} />
+      </label>
+      {detail.data && (
+        <div className="card">
+          <h2>{detail.data.name}</h2>
+          <p>{detail.data.description}</p>
+          <p>{Number(detail.data.price).toLocaleString()} KRW / stock {detail.data.stock}</p>
+          <AddCartButton productId={productId} />
+          <h3>Options</h3>
+          <pre>{JSON.stringify(detail.data.options, null, 2)}</pre>
+          <h3>Images</h3>
+          <pre>{JSON.stringify(detail.data.images, null, 2)}</pre>
+        </div>
+      )}
+      <CreateReviewForm productId={productId} />
+      <h2>Reviews</h2>
+      <div className="stack">
+        {(reviews.data?.data ?? []).map((item) => (
+          <div className="card row" key={item.id}>
+            <span>{item.rating} / {item.content}</span>
+            <UpdateReviewButton reviewId={item.id} productId={productId} content={item.content} />
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
`web-post`, `web-shop`를 FSD 5-layer 기준으로 재구성하고, 단순한 흰 배경/검은 글씨 UI로 정리합니다.

## Scope
- `app/pages/widgets/features/entities/shared` 구조 적용
- `web-post`, `web-shop` 라우트 유지
- 공통 API client/type 정리
- auth/session/entity/feature/widget/page 재배치

## Implemented
- `web-post`: boards, post-detail, mypage, admin panels
- `web-shop`: products, product-detail, cart, checkout, orders, mypage, admin panels
- FSD 레이어별 책임 분리
- shared API client와 entity model/query 분리
- 페이지는 조립만 담당하고 로직은 widgets/features/entities로 이동

## Validation
- `npm run build`
- `npm run test`
- Playwright smoke for main navigation
- 기존 라우트 유지 확인

## UI Notes
- 흰 배경 + 검은 글씨 중심의 최소 UI를 유지합니다.
- 관리자 화면도 별도 앱으로 분리하지 않고 `/admin/*` 라우트 내부에서 처리합니다.

Closes #6