### PR TITLE
docs: (#15) 루트 README와 Document 인덱스 정리

### DIFF
--- a/Document/README.md
+++ b/Document/README.md
@@ -1,0 +1,100 @@
+# Document Index
+
+`Document` 폴더는 `Project-Bible`의 구현 기준 문서를 모아 두는 루트입니다. 문서는 `post`, `shop`, `cli` 세 축으로 정리합니다.
+
+## 문서 구성
+
+- [post](post)
+- [shop](shop)
+- [cli](cli/README.md)
+- [.code-convention](.code-convention)
+
+## Post 문서
+
+- [01_requirements.md](post/01_requirements.md)
+  - `post` 도메인 범위와 제외 범위
+- [02_erd.md](post/02_erd.md)
+  - `users`, `admins`, `boards`, `posts`, `comments`, `post_likes` 중심 ERD
+- [03_api-specification.md](post/03_api-specification.md)
+  - 사용자/관리자 인증, 게시판, 게시글, 댓글, 좋아요, 관리자 운영 API
+- [04_language.md](post/04_language.md)
+  - 현재 실제 `post` 백엔드 6개 구현체 기준
+- [05_test-specification.md](post/05_test-specification.md)
+  - `post` 도메인 테스트 세트
+- [06_ci-specification.md](post/06_ci-specification.md)
+  - `post` CI 기준과 검증 축
+- [07_folder-java.md](post/07_folder-java.md)
+  - Java 표준 폴더 구조
+- [07_folder-typescript.md](post/07_folder-typescript.md)
+  - TypeScript 표준 폴더 구조
+
+## Shop 문서
+
+- [01_requirements.md](shop/01_requirements.md)
+  - `shop` 도메인 범위와 제외 범위
+- [02_erd.md](shop/02_erd.md)
+  - 카테고리, 상품, 주문, 결제, 리뷰 중심 ERD
+- [03_api-specification.md](shop/03_api-specification.md)
+  - 사용자/관리자 인증, 카테고리, 상품, 장바구니, 배송지, 주문, 결제, 리뷰, 관리자 운영 API
+- [04_language.md](shop/04_language.md)
+  - 현재 실제 `shop` 백엔드 6개 구현체 기준
+- [05_test-specification.md](shop/05_test-specification.md)
+  - `shop` 도메인 테스트 세트
+- [06_ci-specification.md](shop/06_ci-specification.md)
+  - `shop` CI 기준과 검증 축
+- [07_folder-java.md](shop/07_folder-java.md)
+  - Java 표준 폴더 구조
+- [07_folder-typescript.md](shop/07_folder-typescript.md)
+  - TypeScript 표준 폴더 구조
+
+## CLI 문서
+
+- [README.md](cli/README.md)
+  - CLI 문서 인덱스
+- [01_command-reference.md](cli/01_command-reference.md)
+  - 명령어 표와 구현 상태
+- [02_setup-and-target-registration.md](cli/02_setup-and-target-registration.md)
+  - 설치, 실행, 타깃 등록 규칙
+- [03_runbook.md](cli/03_runbook.md)
+  - 실제 사용 시나리오
+
+## 코드/협업 규칙
+
+- [.code-convention/convention.md](.code-convention/convention.md)
+  - 이슈, 브랜치, 커밋 메시지 규칙
+- `.github/ISSUE_TEMPLATE`
+  - GitHub 이슈 템플릿
+
+## 문서 읽는 순서
+
+### 도메인 구현을 이해할 때
+
+1. `01_requirements.md`
+2. `02_erd.md`
+3. `03_api-specification.md`
+4. `04_language.md`
+5. `05_test-specification.md`
+6. `06_ci-specification.md`
+7. `07_folder-*.md`
+
+### 저장소 실행/운영을 이해할 때
+
+1. [../README.md](../README.md)
+2. [cli/README.md](cli/README.md)
+3. [cli/01_command-reference.md](cli/01_command-reference.md)
+4. [cli/02_setup-and-target-registration.md](cli/02_setup-and-target-registration.md)
+5. [cli/03_runbook.md](cli/03_runbook.md)
+
+## 현재 기준 요약
+
+- Backend
+  - `post` 6개
+  - `shop` 6개
+  - 총 12개
+- Frontend
+  - `web-post`
+  - `web-shop`
+- Database
+  - PostgreSQL, MySQL 공용 인프라
+- Tools
+  - 공용 CLI와 CI 보조 스크립트

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 `Project-Bible`는 동일한 `post`/`shop` 도메인을 여러 기술 스택으로 구현하고, 공용 `Database`, `Tools/cli`, 프론트엔드 앱, 문서 세트를 함께 관리하는 저장소입니다.
 
+[![frontend-cli CI](https://github.com/hawon6691/Project-Bible/actions/workflows/frontend-cli-ci.yml/badge.svg)](https://github.com/hawon6691/Project-Bible/actions/workflows/frontend-cli-ci.yml)
+[![post-java-springboot-maven-postgresql CI](https://github.com/hawon6691/Project-Bible/actions/workflows/post-java-springboot-maven-postgresql-ci.yml/badge.svg)](https://github.com/hawon6691/Project-Bible/actions/workflows/post-java-springboot-maven-postgresql-ci.yml)
+[![post-typescript-nestjs-npm-postgresql CI](https://github.com/hawon6691/Project-Bible/actions/workflows/post-typescript-nestjs-npm-postgresql-ci.yml/badge.svg)](https://github.com/hawon6691/Project-Bible/actions/workflows/post-typescript-nestjs-npm-postgresql-ci.yml)
+[![shop-java-springboot-maven-postgresql CI](https://github.com/hawon6691/Project-Bible/actions/workflows/shop-java-springboot-maven-postgresql-ci.yml/badge.svg)](https://github.com/hawon6691/Project-Bible/actions/workflows/shop-java-springboot-maven-postgresql-ci.yml)
+[![shop-typescript-nestjs-npm-postgresql CI](https://github.com/hawon6691/Project-Bible/actions/workflows/shop-typescript-nestjs-npm-postgresql-ci.yml/badge.svg)](https://github.com/hawon6691/Project-Bible/actions/workflows/shop-typescript-nestjs-npm-postgresql-ci.yml)
+
 ## 개요
 
 - Backend
@@ -140,6 +146,42 @@ pb up web-shop
 ```powershell
 pb up web-post --port 3005
 pb up post-java-springboot-maven-postgresql --port 8011
+```
+
+## 대표 실행 예시
+
+### Backend
+
+```powershell
+pb up post-java-springboot-maven-postgresql --port 8011
+pb up shop-typescript-nestjs-npm-postgresql --port 8021
+pb down post-java-springboot-maven-postgresql
+pb down shop-typescript-nestjs-npm-postgresql
+```
+
+### Frontend
+
+```powershell
+pb up web-post --port 3000
+pb up web-shop --port 3001
+pb down web-post
+pb down web-shop
+```
+
+### Database
+
+```powershell
+pb db up
+pb db reset postgresql post
+pb db reset mysql shop
+pb db down
+```
+
+### 검증
+
+```powershell
+pb test post-java-springboot-maven-postgresql
+pb test shop-typescript-nestjs-npm-postgresql
 ```
 
 ## 검증 기준

--- a/README.md
+++ b/README.md
@@ -1,0 +1,164 @@
+# Project-Bible
+
+`Project-Bible`는 동일한 `post`/`shop` 도메인을 여러 기술 스택으로 구현하고, 공용 `Database`, `Tools/cli`, 프론트엔드 앱, 문서 세트를 함께 관리하는 저장소입니다.
+
+## 개요
+
+- Backend
+  - `post` 6개
+  - `shop` 6개
+  - 총 12개 구현체
+- Frontend
+  - `Frontend/web-post`
+  - `Frontend/web-shop`
+- Database
+  - `Database/postgresql`
+  - `Database/mysql`
+  - 공용 Docker 인프라: `Database/docker`
+- Tools
+  - 공용 CLI: `Tools/cli`
+  - CI 보조 스크립트: `Tools/ci`
+- Document
+  - 요구사항, ERD, API, 테스트, CI, 폴더 구조, CLI 문서
+
+## 저장소 구조
+
+```text
+Project-Bible/
+├─ Backend/
+│  ├─ post/
+│  └─ shop/
+├─ Frontend/
+│  ├─ web-post/
+│  └─ web-shop/
+├─ Database/
+│  ├─ docker/
+│  ├─ postgresql/
+│  └─ mysql/
+├─ Tools/
+│  ├─ cli/
+│  └─ ci/
+└─ Document/
+   ├─ post/
+   ├─ shop/
+   └─ cli/
+```
+
+## 백엔드 매트릭스
+
+### Post
+
+- Java
+  - `post-java-springboot-maven-postgresql`
+  - `post-java-springboot-maven-mysql`
+  - `post-java-springboot-gradle-postgresql`
+  - `post-java-springboot-gradle-mysql`
+- TypeScript
+  - `post-typescript-nestjs-npm-postgresql`
+  - `post-typescript-nestjs-npm-mysql`
+
+### Shop
+
+- Java
+  - `shop-java-springboot-maven-postgresql`
+  - `shop-java-springboot-maven-mysql`
+  - `shop-java-springboot-gradle-postgresql`
+  - `shop-java-springboot-gradle-mysql`
+- TypeScript
+  - `shop-typescript-nestjs-npm-postgresql`
+  - `shop-typescript-nestjs-npm-mysql`
+
+## 프론트엔드 구조
+
+프론트엔드는 `React + Vite + TypeScript` 기반이며 FSD 5-layer를 사용합니다.
+
+- `app`
+- `pages`
+- `widgets`
+- `features`
+- `entities`
+- `shared`
+
+화면 구성은 흰 배경과 검은 글씨 중심의 단순한 스타일을 유지합니다.
+
+## 공통 계약
+
+- API 경로
+  - 일반 API: `/api/v1/...`
+  - 관리자 API: `/api/v1/admin/...`
+- Swagger
+  - `/docs`
+- 응답 envelope
+  - 성공: `{ success: true, data, meta? }`
+  - 실패: `{ success: false, error: { code, message, details? } }`
+- 인증
+  - 사용자 JWT와 관리자 JWT 분리
+
+## 빠른 시작
+
+### 1. 문서 확인
+
+- 전체 문서 인덱스: [Document/README.md](Document/README.md)
+- `post` 문서: [Document/post](Document/post)
+- `shop` 문서: [Document/shop](Document/shop)
+- CLI 문서: [Document/cli/README.md](Document/cli/README.md)
+
+### 2. CLI 설치
+
+```powershell
+cd Tools/cli
+python -m pip install -e .
+```
+
+### 3. 타깃 확인
+
+```powershell
+pb list
+pb /?
+pb search post
+```
+
+### 4. Database 기동
+
+```powershell
+pb db up
+pb db reset postgresql post
+pb db reset postgresql shop
+```
+
+### 5. 앱 실행
+
+```powershell
+pb up post-java-springboot-maven-postgresql
+pb up shop-typescript-nestjs-npm-postgresql
+pb up web-post
+pb up web-shop
+```
+
+필요하면 포트를 직접 지정할 수 있습니다.
+
+```powershell
+pb up web-post --port 3005
+pb up post-java-springboot-maven-postgresql --port 8011
+```
+
+## 검증 기준
+
+현재 저장소는 아래 기준으로 정리되어 있습니다.
+
+- Backend 12개 workflow 개별 GitHub Actions 구성
+- Frontend/CLI 전용 workflow 구성
+- PostgreSQL/MySQL schema 및 seed 제공
+- CLI 기반 실행/중지/DB 제어 지원
+- 프론트엔드 build/test/smoke, 백엔드 build/test/e2e, HTTP matrix 검증 기준 정리
+
+## 문서 맵
+
+- `Document/post`
+  - 요구사항, ERD, API, 테스트, CI, 언어/폴더 구조
+- `Document/shop`
+  - 요구사항, ERD, API, 테스트, CI, 언어/폴더 구조
+- `Document/cli`
+  - 명령어, 설정, runbook
+
+상세 문서 인덱스는 [Document/README.md](Document/README.md)에서 확인합니다.


### PR DESCRIPTION
## Summary
루트 진입 문서와 `Document` 인덱스를 정리해 저장소 구조, 문서 흐름, CLI 빠른 시작을 한 번에 파악할 수 있게 만듭니다.

## Scope
- 루트 `README.md` 작성 및 보강
- `Document/README.md` 작성
- 현재 실제 backend/frontend/database/tools 구조 기준 안내 정리
- 대표 GitHub Actions 배지 추가
- CLI 대표 실행 예시 추가

## Implemented
- 저장소 개요, 백엔드 12개 매트릭스, 프론트 FSD 구조, 공통 API 계약 정리
- `Document/post`, `Document/shop`, `Document/cli`, `.code-convention` 인덱스 정리
- 문서 읽는 순서와 빠른 시작 경로 정리
- 대표 workflow badge 추가
- `pb up`, `pb down`, `pb db`, `pb test` 대표 실행 예시 추가

## Validation
- README 링크 경로 점검
- `Document/README.md` 인덱스와 실제 파일 구조 일치 여부 점검
- 작업 트리 clean 확인

## Notes
- 이 PR은 문서 진입성과 탐색성을 높이는 목적입니다.
- 상세 구현 규칙은 기존 `Document/post`, `Document/shop`, `Document/cli` 문서를 그대로 기준으로 사용합니다.

Closes #15