### PR TITLE
chore: (#21) CLI 래퍼와 DB reset 확인 절차 추가

### DIFF
--- a/Document/cli/01_command-reference.md
+++ b/Document/cli/01_command-reference.md
@@ -17,6 +17,8 @@
 - `pb down <target>`은 CLI 런타임 상태에 저장된 PID를 종료한다.
 - `pb down --port N`은 해당 포트의 CLI 추적 프로세스 또는 포트를 점유 중인 프로세스를 종료한다.
 - `pb db up`, `pb db down`, `pb db reset`은 Docker 기반 DB 명령으로 동작한다.
+- `pb db reset`은 기존 DB를 덮어쓰기 전에 `Y/N` 확인을 요구한다.
+- 저장소 루트의 `pb.cmd`는 패키지 설치 없이 같은 CLI를 실행하는 Windows 래퍼다.
 
 ## 명령어 표
 
@@ -29,7 +31,7 @@
 | `pb test <target>` | `target` | 지정한 타깃의 테스트 명령을 현재 콘솔에서 실행한다. | `implemented` | backend, frontend | `pb test shop-typescript-nestjs-npm-postgresql` |
 | `pb db up` | 없음 | 공용 DB 인프라를 `docker compose up -d`로 기동한다. | `implemented` | database | `pb db up` |
 | `pb db down` | 없음 | 공용 DB 인프라를 `docker compose down`으로 종료한다. | `implemented` | database | `pb db down` |
-| `pb db reset <engine> <domain>` | `engine`, `domain` | 지정한 DB 엔진과 도메인 기준으로 DB를 drop/create 후 schema와 seed를 다시 적용한다. | `implemented` | database | `pb db reset postgresql post` |
+| `pb db reset <engine> <domain> [--yes]` | `engine`, `domain`, `yes` | 지정한 DB 엔진과 도메인 기준으로 DB를 drop/create 후 schema와 seed를 다시 적용한다. 기본 동작은 `Y/N` 확인을 요구한다. | `implemented` | database | `pb db reset postgresql post` |
 | `pb doctor` | 없음 | 로컬 실행 환경과 필수 도구 상태를 점검한다. | `implemented` | 공용 | `pb doctor` |
 | `pb gui` | 없음 | Tkinter 기반 로컬 GUI를 실행한다. | `implemented` | 공용 | `pb gui` |
 | `pb search <keyword>` | `keyword` | 명령어, 예시, 등록 타깃을 키워드로 검색한다. | `implemented` | 공용 | `pb search web` |
@@ -45,7 +47,7 @@
 - `pb down`은 저장된 PID 또는 지정 포트를 기준으로 대상 프로세스를 종료한다.
 - `pb test`는 등록된 `test_command`를 해당 프로젝트 경로에서 실행한다.
 - `pb db up`, `pb db down`은 `Database/docker/docker-compose.yml`을 기준으로 동작한다.
-- `pb db reset`은 엔진별 SQL 파일을 컨테이너 내부 DB에 다시 적용한다.
+- `pb db reset`은 엔진별 SQL 파일을 컨테이너 내부 DB에 다시 적용하며, 덮어쓰기 전 확인을 받는다.
 - `pb doctor`는 Python, Node, npm, Java, Docker 존재 여부를 점검한다.
 - `pb gui`는 Tkinter GUI를 띄워 같은 기능을 호출한다.
 - `pb search`는 명령어와 등록 타깃 이름을 키워드로 검색한다.
@@ -93,3 +95,5 @@ Stopped untracked process using port 3000 (PID ...)
 - CLI 식별자와 실제 폴더명이 다르면 운영 규칙이 깨지므로 허용하지 않는다.
 - `pb down <target>`은 `pb up`으로 기록된 PID가 없으면 종료할 대상을 찾지 못한다.
 - `pb down --port N`은 CLI 상태에 없는 프로세스도 포트를 점유 중이면 `taskkill`로 종료할 수 있으므로 포트 번호를 확인하고 실행해야 한다.
+- `pb db reset`에서 `Y` 또는 `yes`가 아닌 값을 입력하면 작업을 중지한다.
+- 자동화 환경에서만 `pb db reset <engine> <domain> --yes`로 확인을 생략한다.

--- a/Document/cli/03_runbook.md
+++ b/Document/cli/03_runbook.md
@@ -14,6 +14,12 @@ cd Tools/cli
 python -m pip install -e .
 ```
 
+설치 없이 저장소 루트 래퍼로 실행:
+
+```powershell
+.\pb.cmd list
+```
+
 설치 확인:
 
 ```powershell
@@ -86,9 +92,18 @@ pb db reset postgresql post
 
 현재 기대 동작:
 
+- `pb_post` 덮어쓰기 여부를 `Y/N`으로 확인
 - PostgreSQL 컨테이너 안에서 `pb_post`를 drop/create
 - `Database/postgresql/post/init/01_schema.sql` 적용
 - `Database/postgresql/post/seeds/01_seed.sql` 적용
+
+`Y` 또는 `yes`를 입력하면 덮어쓰고, `N` 또는 Enter를 입력하면 중지한다.
+
+자동화가 필요한 경우에만 확인을 생략한다.
+
+```powershell
+pb db reset postgresql post --yes
+```
 
 ## 로컬 점검 시나리오
 
@@ -145,6 +160,7 @@ pb up web-post --port 3000
 - `backend`, `frontend`, `database` 그룹 키를 바꾸는 경우
 - 백엔드 이름에서 `springboot`, `nestjs`, `maven`, `gradle`, `npm`, `postgresql`, `mysql` 같은 고정 토큰을 임의로 변경하는 경우
 - `pb db reset` 전에 DB 컨테이너를 올리지 않는 경우
+- `pb db reset` 확인 프롬프트에서 실수로 `Y`를 입력해 기존 데이터를 덮어쓰는 경우
 - `pb down` 호출 전에 `pb up` 기록이 없는 경우
 - 이미 열려 있는 포트를 `pb up <target> --port N`으로 다시 지정하는 경우
 

--- a/Tools/cli/README.md
+++ b/Tools/cli/README.md
@@ -13,10 +13,18 @@ Shared Python CLI for Project-Bible scaffolding, local orchestration, and checks
 - `pb db up`
 - `pb db down`
 - `pb db reset <engine> <domain>`
+- `pb db reset <engine> <domain> --yes`
 - `pb doctor`
 - `pb gui`
 - `pb search <keyword>`
 - `pb --help`, `pb <command> --help`, `pb /?`, `pb <command> /?`
+
+From the repository root, `pb.cmd` runs the same CLI without installing the package first:
+
+```powershell
+.\pb.cmd list
+.\pb.cmd db reset mysql shop
+```
 
 ## Runtime
 
@@ -27,3 +35,4 @@ Shared Python CLI for Project-Bible scaffolding, local orchestration, and checks
 - If a requested port is already open, the CLI prints the occupying target or PID and asks you to stop it first with `pb down <target>` or `pb down --port <number>`.
 - Command help supports both Unix-style `--help` and Windows-style `/?`.
 - `pb search <keyword>` searches command names, descriptions, examples, and registered target names.
+- `pb db reset` drops and recreates the selected database, then applies `init/01_schema.sql` and `seeds/01_seed.sql`. It asks for `Y/N` confirmation before overwriting; use `--yes` only for scripted runs.

--- a/Tools/cli/src/pbcli/main.py
+++ b/Tools/cli/src/pbcli/main.py
@@ -51,6 +51,7 @@ def build_parser() -> argparse.ArgumentParser:
     reset_parser = db_subparsers.add_parser("reset", help="Reset a database domain")
     reset_parser.add_argument("engine", choices=("postgresql", "mysql"))
     reset_parser.add_argument("domain", choices=("post", "shop"))
+    reset_parser.add_argument("-y", "--yes", action="store_true", help="Skip overwrite confirmation")
     reset_parser.set_defaults(func=cmd_db_reset)
 
     doctor_parser = subparsers.add_parser("doctor", help="Check local toolchain")

--- a/Tools/cli/src/pbcli/services.py
+++ b/Tools/cli/src/pbcli/services.py
@@ -305,8 +305,39 @@ def _docker_compose(command: str) -> int:
     return _run_local(f"docker compose -f '{compose}' {command}", REPO_ROOT)
 
 
-def _apply_postgresql_sql(domain: str) -> int:
+def _database_env() -> dict[str, str]:
+    env_path = REPO_ROOT / "Database" / "docker" / ".env"
+    fallback_path = REPO_ROOT / "Database" / "docker" / ".env.example"
+    source = env_path if env_path.exists() else fallback_path
+    values: dict[str, str] = {}
+    if not source.exists():
+        return values
+    for line in source.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def _confirm_database_overwrite(engine: str, domain: str, db_name: str, assume_yes: bool) -> None:
+    if assume_yes:
+        return
+    prompt = (
+        f"This will drop and recreate {engine} database '{db_name}' for domain '{domain}'. "
+        "Continue? [Y/N]: "
+    )
+    answer = input(prompt).strip().lower()
+    if answer not in {"y", "yes"}:
+        raise SystemExit("Database reset cancelled.")
+
+
+def _apply_postgresql_sql(domain: str, assume_yes: bool = False) -> int:
     db_name = f"pb_{domain}"
+    _confirm_database_overwrite("postgresql", domain, db_name, assume_yes)
+    env = _database_env()
+    user = env.get("POSTGRES_USER", "admin")
     init_dir = REPO_ROOT / "Database" / "postgresql" / domain
     schema_file = init_dir / "init" / "01_schema.sql"
     seed_file = init_dir / "seeds" / "01_seed.sql"
@@ -318,7 +349,7 @@ def _apply_postgresql_sql(domain: str) -> int:
             "projectbible-postgres",
             "psql",
             "-U",
-            "project_bible",
+            user,
             "-d",
             "postgres",
             "-c",
@@ -338,7 +369,7 @@ def _apply_postgresql_sql(domain: str) -> int:
             "projectbible-postgres",
             "psql",
             "-U",
-            "project_bible",
+            user,
             "-d",
             "postgres",
             "-c",
@@ -354,7 +385,7 @@ def _apply_postgresql_sql(domain: str) -> int:
             "projectbible-postgres",
             "psql",
             "-U",
-            "project_bible",
+            user,
             "-d",
             "postgres",
             "-c",
@@ -365,19 +396,19 @@ def _apply_postgresql_sql(domain: str) -> int:
     for file_path in (schema_file, seed_file):
         sql = file_path.read_text(encoding="utf-8")
         subprocess.run(
-        [
-            "docker",
-            "exec",
-            "-i",
-            "projectbible-postgres",
-            "psql",
-            "-U",
-            "project_bible",
-            "-d",
-            db_name,
-            "-v",
-            "ON_ERROR_STOP=1",
-        ],
+            [
+                "docker",
+                "exec",
+                "-i",
+                "projectbible-postgres",
+                "psql",
+                "-U",
+                user,
+                "-d",
+                db_name,
+                "-v",
+                "ON_ERROR_STOP=1",
+            ],
             input=sql,
             text=True,
             check=True,
@@ -386,8 +417,11 @@ def _apply_postgresql_sql(domain: str) -> int:
     return 0
 
 
-def _apply_mysql_sql(domain: str) -> int:
+def _apply_mysql_sql(domain: str, assume_yes: bool = False) -> int:
     db_name = f"pb_{domain}"
+    _confirm_database_overwrite("mysql", domain, db_name, assume_yes)
+    env = _database_env()
+    root_password = env.get("MYSQL_ROOT_PASSWORD", "1234")
     init_dir = REPO_ROOT / "Database" / "mysql" / domain
     schema_file = init_dir / "init" / "01_schema.sql"
     seed_file = init_dir / "seeds" / "01_seed.sql"
@@ -399,7 +433,7 @@ def _apply_mysql_sql(domain: str) -> int:
             "projectbible-mysql",
             "mysql",
             "-uroot",
-            "-pproject_bible",
+            f"-p{root_password}",
             "-e",
             f"DROP DATABASE IF EXISTS {db_name}; CREATE DATABASE {db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
         ],
@@ -412,13 +446,13 @@ def _apply_mysql_sql(domain: str) -> int:
                 "docker",
                 "exec",
                 "-i",
-            "projectbible-mysql",
-            "mysql",
-            "-uroot",
-            "-pproject_bible",
-            "--default-character-set=utf8mb4",
-            db_name,
-        ],
+                "projectbible-mysql",
+                "mysql",
+                "-uroot",
+                f"-p{root_password}",
+                "--default-character-set=utf8mb4",
+                db_name,
+            ],
             input=sql,
             text=True,
             check=True,
@@ -437,9 +471,9 @@ def cmd_db_down(_args: argparse.Namespace) -> int:
 
 def cmd_db_reset(args: argparse.Namespace) -> int:
     if args.engine == "postgresql":
-        return _apply_postgresql_sql(args.domain)
+        return _apply_postgresql_sql(args.domain, getattr(args, "yes", False))
     if args.engine == "mysql":
-        return _apply_mysql_sql(args.domain)
+        return _apply_mysql_sql(args.domain, getattr(args, "yes", False))
     raise SystemExit(f"Unsupported engine: {args.engine}")
 
 

--- a/pb.cmd
+++ b/pb.cmd
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+
+set "PB_ROOT=%~dp0"
+set "PYTHONPATH=%PB_ROOT%Tools\cli\src;%PYTHONPATH%"
+
+python -m pbcli.main %*
+exit /b %ERRORLEVEL%


### PR DESCRIPTION
## Summary

- Adds a root `pb.cmd` wrapper so the shared CLI can run from the repository root without editable install.
- Adds a `Y/N` confirmation before `pb db reset` overwrites an existing domain database.
- Adds `--yes` for scripted database reset flows.

## Implemented

- Root `pb.cmd` sets `PYTHONPATH` to `Tools/cli/src` and delegates to `python -m pbcli.main`.
- `pb db reset <engine> <domain>` now asks before drop/create and cancels unless the user enters `Y` or `yes`.
- `pb db reset --yes` skips the prompt for automation.
- DB reset now reads Docker DB credentials from `Database/docker/.env`, falling back to `.env.example`.
- CLI docs describe the wrapper, confirmation behavior, and `--yes` option.

## Validation

- `git diff --cached --check`
- `python -m py_compile Tools\\cli\\src\\pbcli\\main.py Tools\\cli\\src\\pbcli\\services.py`
- `.\\pb.cmd list`
- `.\\pb.cmd db reset --help`
- `"N" | .\\pb.cmd db reset mysql post` cancels before overwrite.

Closes #21