### PR TITLE
bug: (#25) MySQL reset 후 앱 계정 권한 누락 수정

### DIFF
--- a/Document/cli/01_command-reference.md
+++ b/Document/cli/01_command-reference.md
@@ -48,6 +48,7 @@
 - `pb test`는 등록된 `test_command`를 해당 프로젝트 경로에서 실행한다.
 - `pb db up`, `pb db down`은 `Database/docker/docker-compose.yml`을 기준으로 동작한다.
 - `pb db reset`은 엔진별 SQL 파일을 컨테이너 내부 DB에 다시 적용하며, 덮어쓰기 전 확인을 받는다.
+- MySQL reset은 `Database/docker/.env`의 `MYSQL_USER` 기준으로 다시 만든 `pb_<domain>` DB 권한도 부여한다.
 - `pb doctor`는 Python, Node, npm, Java, Docker 존재 여부를 점검한다.
 - `pb gui`는 Tkinter GUI를 띄워 같은 기능을 호출한다.
 - `pb search`는 명령어와 등록 타깃 이름을 키워드로 검색한다.

--- a/Tools/cli/README.md
+++ b/Tools/cli/README.md
@@ -36,3 +36,4 @@ From the repository root, `pb.cmd` runs the same CLI without installing the pack
 - Command help supports both Unix-style `--help` and Windows-style `/?`.
 - `pb search <keyword>` searches command names, descriptions, examples, and registered target names.
 - `pb db reset` drops and recreates the selected database, then applies `init/01_schema.sql` and `seeds/01_seed.sql`. It asks for `Y/N` confirmation before overwriting; use `--yes` only for scripted runs.
+- MySQL reset also grants the `MYSQL_USER` from `Database/docker/.env` access to the recreated `pb_<domain>` database.

--- a/Tools/cli/src/pbcli/services.py
+++ b/Tools/cli/src/pbcli/services.py
@@ -333,6 +333,15 @@ def _confirm_database_overwrite(engine: str, domain: str, db_name: str, assume_y
         raise SystemExit("Database reset cancelled.")
 
 
+def _mysql_identifier(value: str) -> str:
+    return f"`{value.replace('`', '``')}`"
+
+
+def _mysql_literal(value: str) -> str:
+    escaped = value.replace("\\", "\\\\").replace("'", "''")
+    return f"'{escaped}'"
+
+
 def _apply_postgresql_sql(domain: str, assume_yes: bool = False) -> int:
     db_name = f"pb_{domain}"
     _confirm_database_overwrite("postgresql", domain, db_name, assume_yes)
@@ -422,20 +431,33 @@ def _apply_mysql_sql(domain: str, assume_yes: bool = False) -> int:
     _confirm_database_overwrite("mysql", domain, db_name, assume_yes)
     env = _database_env()
     root_password = env.get("MYSQL_ROOT_PASSWORD", "1234")
+    app_user = env.get("MYSQL_USER", "admin")
+    app_password = env.get("MYSQL_PASSWORD", "1234")
     init_dir = REPO_ROOT / "Database" / "mysql" / domain
     schema_file = init_dir / "init" / "01_schema.sql"
     seed_file = init_dir / "seeds" / "01_seed.sql"
+    db_identifier = _mysql_identifier(db_name)
+    app_user_literal = _mysql_literal(app_user)
+    app_password_literal = _mysql_literal(app_password)
     subprocess.run(
         [
             "docker",
             "exec",
             "-i",
+            "-e",
+            f"MYSQL_PWD={root_password}",
             "projectbible-mysql",
             "mysql",
             "-uroot",
-            f"-p{root_password}",
             "-e",
-            f"DROP DATABASE IF EXISTS {db_name}; CREATE DATABASE {db_name} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;",
+            (
+                f"DROP DATABASE IF EXISTS {db_identifier}; "
+                f"CREATE DATABASE {db_identifier} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci; "
+                f"CREATE USER IF NOT EXISTS {app_user_literal}@'%' IDENTIFIED BY {app_password_literal}; "
+                f"ALTER USER {app_user_literal}@'%' IDENTIFIED BY {app_password_literal}; "
+                f"GRANT ALL PRIVILEGES ON {db_identifier}.* TO {app_user_literal}@'%'; "
+                "FLUSH PRIVILEGES;"
+            ),
         ],
         check=True,
     )
@@ -446,10 +468,11 @@ def _apply_mysql_sql(domain: str, assume_yes: bool = False) -> int:
                 "docker",
                 "exec",
                 "-i",
+                "-e",
+                f"MYSQL_PWD={root_password}",
                 "projectbible-mysql",
                 "mysql",
                 "-uroot",
-                f"-p{root_password}",
                 "--default-character-set=utf8mb4",
                 db_name,
             ],


### PR DESCRIPTION
## Summary
- Fix `pb db reset mysql <domain>` so recreated MySQL databases are usable by the configured application account.
- Keep the existing Y/N overwrite confirmation behavior.
- Document the MySQL reset grant behavior in CLI docs.

## Fixed
- Reads `MYSQL_USER` and `MYSQL_PASSWORD` from `Database/docker/.env` with the existing defaults.
- Recreates `pb_<domain>`, creates/updates the app user, grants privileges on that database, and flushes privileges before applying schema/seed SQL.
- Uses `MYSQL_PWD` for MySQL CLI calls to avoid password CLI warnings during reset.

## Validation
- `python -m py_compile Tools\cli\src\pbcli\services.py`
- `.\\pb.cmd db reset --help`
- `"n" | .\pb.cmd db reset mysql shop` cancels with `Database reset cancelled.`
- `"y" | .\pb.cmd db reset mysql shop`
- `"y" | .\pb.cmd db reset mysql post`
- `docker exec -e MYSQL_PWD=1234 projectbible-mysql mysql -uadmin -N -e "SHOW DATABASES LIKE 'pb_%';"` returns `pb_post`, `pb_shop`, `pbdb`
- `docker exec -e MYSQL_PWD=1234 projectbible-mysql mysql -uadmin -N -e "SELECT table_schema, COUNT(*) FROM information_schema.tables WHERE table_schema IN ('pb_post','pb_shop') GROUP BY table_schema ORDER BY table_schema;"` returns `pb_post 8`, `pb_shop 15`
- `git diff --check`

Closes #25