### PR TITLE
feat: (#27) CLI runtime status 명령 추가

### DIFF
--- a/Document/cli/01_command-reference.md
+++ b/Document/cli/01_command-reference.md
@@ -13,6 +13,7 @@
 - `domain`은 `post`, `shop`만 사용한다.
 - `pb up`은 새 PowerShell 창을 열어 대상 서버를 실행한다.
 - `pb up`은 `--port`가 없으면 backend는 `8000`, frontend는 `3000`부터 자동 증가 포트를 할당한다.
+- `pb status`는 CLI가 추적 중인 실행 대상의 name, kind, PID, port, started_at을 출력한다.
 - backend Swagger 기본 경로는 `/docs`다.
 - `pb down <target>`은 CLI 런타임 상태에 저장된 PID를 종료한다.
 - `pb down --port N`은 해당 포트의 CLI 추적 프로세스 또는 포트를 점유 중인 프로세스를 종료한다.
@@ -25,6 +26,7 @@
 | 명령 | 인자 | 설명 | 현재 상태 | 대상 그룹 | 예시 |
 | --- | --- | --- | --- | --- | --- |
 | `pb list` | 없음 | 등록된 백엔드, 프론트, DB 타깃 목록을 출력한다. | `implemented` | 공용 | `pb list` |
+| `pb status` | 없음 | CLI가 추적 중인 실행 대상과 할당 포트를 출력한다. | `implemented` | backend, frontend | `pb status` |
 | `pb up <target> [--port N]` | `target`, `port` | 지정한 타깃을 새 PowerShell 창에서 기동한다. 포트를 주지 않으면 그룹 기준 자동 할당한다. | `implemented` | backend, frontend | `pb up post-java-springboot-maven-postgresql --port 9010` |
 | `pb down <target>` | `target` | CLI가 추적 중인 대상 프로세스를 종료한다. | `implemented` | backend, frontend | `pb down web-shop` |
 | `pb down --port N` | `port` | 지정한 포트를 점유 중인 CLI 추적 프로세스 또는 로컬 프로세스를 종료한다. | `implemented` | backend, frontend, local process | `pb down --port 3000` |
@@ -43,6 +45,7 @@
 현재 `main.py` 기준 동작은 아래와 같다.
 
 - `pb list`는 `projects.yaml`을 읽어 `backend`, `frontend`, `database` 그룹별 타깃을 출력한다.
+- `pb status`는 현재 살아 있는 CLI 추적 프로세스를 출력하며, 이미 종료된 PID는 런타임 상태에서 정리한다.
 - `pb up`은 등록된 `start_command`를 새 PowerShell 창에서 실행하고 PID와 할당 포트를 기록한다.
 - `pb down`은 저장된 PID 또는 지정 포트를 기준으로 대상 프로세스를 종료한다.
 - `pb test`는 등록된 `test_command`를 해당 프로젝트 경로에서 실행한다.
@@ -84,6 +87,9 @@
 
 ```text
 Started post-java-springboot-maven-postgresql in new PowerShell window (PID ..., port 8000)
+name                                  kind     pid    port  started_at
+------------------------------------  -------  -----  ----  -------------------------
+post-java-springboot-maven-postgresql backend  12345  8000  2026-04-24T12:00:00
 Stopped web-shop (PID ..., port 3001)
 Stopped untracked process using port 3000 (PID ...)
 ```

--- a/Document/cli/README.md
+++ b/Document/cli/README.md
@@ -15,6 +15,7 @@
 ## 현재 상태 요약
 
 - `pb list`: 실제 동작
+- `pb status`: 실제 동작
 - `pb up <target>`: 실제 동작
 - `pb down <target>`: 실제 동작
 - `pb test <target>`: 실제 동작

--- a/Tools/cli/README.md
+++ b/Tools/cli/README.md
@@ -5,6 +5,7 @@ Shared Python CLI for Project-Bible scaffolding, local orchestration, and checks
 ## Commands
 
 - `pb list`
+- `pb status`
 - `pb up <target>`
 - `pb up <target> --port <number>`
 - `pb down <target>`
@@ -23,6 +24,7 @@ From the repository root, `pb.cmd` runs the same CLI without installing the pack
 
 ```powershell
 .\pb.cmd list
+.\pb.cmd status
 .\pb.cmd db reset mysql shop
 ```
 
@@ -31,6 +33,7 @@ From the repository root, `pb.cmd` runs the same CLI without installing the pack
 - Process state file: `Tools/cli/.runtime/state.json`
 - Target registry: `Tools/cli/src/pbcli/config/projects.yaml`
 - GUI: Tkinter desktop panel backed by the same CLI service layer
+- `pb status` prints the active CLI-tracked target name, kind, PID, assigned port, and start time.
 - Default port policy: backend starts at `8000`, frontend starts at `3000`, then auto-increments by active runtime state
 - If a requested port is already open, the CLI prints the occupying target or PID and asks you to stop it first with `pb down <target>` or `pb down --port <number>`.
 - Command help supports both Unix-style `--help` and Windows-style `/?`.

--- a/Tools/cli/src/pbcli/main.py
+++ b/Tools/cli/src/pbcli/main.py
@@ -12,6 +12,7 @@ from pbcli.services import (
     cmd_down,
     cmd_list,
     cmd_search,
+    cmd_status,
     cmd_test,
     cmd_up,
 )
@@ -23,6 +24,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     list_parser = subparsers.add_parser("list", help="List registered targets")
     list_parser.set_defaults(func=cmd_list)
+
+    status_parser = subparsers.add_parser("status", help="List running CLI-tracked targets")
+    status_parser.set_defaults(func=cmd_status)
 
     up_parser = subparsers.add_parser("up", help="Start a target in a new PowerShell window")
     up_parser.add_argument("target")

--- a/Tools/cli/src/pbcli/services.py
+++ b/Tools/cli/src/pbcli/services.py
@@ -192,10 +192,38 @@ def cmd_list(_args: argparse.Namespace) -> int:
     return 0
 
 
+def _print_runtime_table(rows: list[dict[str, str]]) -> None:
+    columns = [
+        ("name", "name"),
+        ("kind", "kind"),
+        ("pid", "pid"),
+        ("port", "assigned_port"),
+        ("started_at", "started_at"),
+    ]
+    widths = {
+        label: max(len(label), *(len(row[key]) for row in rows))
+        for label, key in columns
+    }
+    print("  ".join(label.ljust(widths[label]) for label, _key in columns))
+    print("  ".join("-" * widths[label] for label, _key in columns))
+    for row in rows:
+        print("  ".join(row[key].ljust(widths[label]) for label, key in columns))
+
+
+def cmd_status(_args: argparse.Namespace) -> int:
+    rows = list_runtime_records()
+    if not rows:
+        print("No tracked processes.")
+        return 0
+    _print_runtime_table(rows)
+    return 0
+
+
 def cmd_search(args: argparse.Namespace) -> int:
     keyword = args.keyword.lower()
     commands = [
         ("list", "List registered targets", "pb list"),
+        ("status", "List running CLI-tracked targets", "pb status"),
         ("up", "Start a target in a new PowerShell window", "pb up web-post --port 3000"),
         ("down", "Stop a tracked target or process by port", "pb down web-post / pb down --port 3000"),
         ("test", "Run tests for a target", "pb test web-shop"),


### PR DESCRIPTION
## Summary
- Add `pb status` to show targets currently tracked by the CLI runtime state.
- Reuse the existing active runtime cleanup path so stale PIDs are removed before output.
- Update CLI docs to include the new command.

## Implemented
- Added `cmd_status` and registered the `status` parser.
- Added tabular output for name, kind, PID, port, and started_at.
- Added `status` to `pb search` results.
- Updated `Tools/cli/README.md`, `Document/cli/README.md`, and `Document/cli/01_command-reference.md`.

## Validation
- `python -m py_compile Tools\cli\src\pbcli\main.py Tools\cli\src\pbcli\services.py`
- `.\pb.cmd status --help`
- `.\pb.cmd status`
- `.\pb.cmd search status`
- `.\pb.cmd --help`
- `git diff --check`

Closes #27