### PR TITLE
bug: (#29) 프론트엔드 API 호출 CORS 허용 누락 수정

### DIFF
--- a/Backend/post/post-java-springboot-gradle-mysql/src/main/java/com/projectbible/post/common/config/CorsConfig.java
+++ b/Backend/post/post-java-springboot-gradle-mysql/src/main/java/com/projectbible/post/common/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.projectbible.post.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                    .allowedOriginPatterns("http://localhost:*", "http://127.0.0.1:*")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+                    .maxAge(3600);
+            }
+        };
+    }
+}

--- a/Backend/post/post-java-springboot-gradle-postgresql/src/main/java/com/projectbible/post/common/config/CorsConfig.java
+++ b/Backend/post/post-java-springboot-gradle-postgresql/src/main/java/com/projectbible/post/common/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.projectbible.post.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                    .allowedOriginPatterns("http://localhost:*", "http://127.0.0.1:*")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+                    .maxAge(3600);
+            }
+        };
+    }
+}

--- a/Backend/post/post-java-springboot-maven-mysql/src/main/java/com/projectbible/post/common/config/CorsConfig.java
+++ b/Backend/post/post-java-springboot-maven-mysql/src/main/java/com/projectbible/post/common/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.projectbible.post.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                    .allowedOriginPatterns("http://localhost:*", "http://127.0.0.1:*")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+                    .maxAge(3600);
+            }
+        };
+    }
+}

--- a/Backend/post/post-java-springboot-maven-postgresql/src/main/java/com/projectbible/post/common/config/CorsConfig.java
+++ b/Backend/post/post-java-springboot-maven-postgresql/src/main/java/com/projectbible/post/common/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.projectbible.post.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                    .allowedOriginPatterns("http://localhost:*", "http://127.0.0.1:*")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+                    .maxAge(3600);
+            }
+        };
+    }
+}

--- a/Backend/shop/shop-java-springboot-gradle-mysql/src/main/java/com/projectbible/shop/common/config/CorsConfig.java
+++ b/Backend/shop/shop-java-springboot-gradle-mysql/src/main/java/com/projectbible/shop/common/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.projectbible.shop.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                    .allowedOriginPatterns("http://localhost:*", "http://127.0.0.1:*")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+                    .maxAge(3600);
+            }
+        };
+    }
+}

--- a/Backend/shop/shop-java-springboot-gradle-postgresql/src/main/java/com/projectbible/shop/common/config/CorsConfig.java
+++ b/Backend/shop/shop-java-springboot-gradle-postgresql/src/main/java/com/projectbible/shop/common/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.projectbible.shop.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                    .allowedOriginPatterns("http://localhost:*", "http://127.0.0.1:*")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+                    .maxAge(3600);
+            }
+        };
+    }
+}

--- a/Backend/shop/shop-java-springboot-maven-mysql/src/main/java/com/projectbible/shop/common/config/CorsConfig.java
+++ b/Backend/shop/shop-java-springboot-maven-mysql/src/main/java/com/projectbible/shop/common/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.projectbible.shop.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                    .allowedOriginPatterns("http://localhost:*", "http://127.0.0.1:*")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+                    .maxAge(3600);
+            }
+        };
+    }
+}

--- a/Backend/shop/shop-java-springboot-maven-postgresql/src/main/java/com/projectbible/shop/common/config/CorsConfig.java
+++ b/Backend/shop/shop-java-springboot-maven-postgresql/src/main/java/com/projectbible/shop/common/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.projectbible.shop.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                    .allowedOriginPatterns("http://localhost:*", "http://127.0.0.1:*")
+                    .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
+                    .maxAge(3600);
+            }
+        };
+    }
+}

--- a/Document/cli/03_runbook.md
+++ b/Document/cli/03_runbook.md
@@ -163,8 +163,11 @@ pb up web-post --port 3000
 - `pb db reset` 확인 프롬프트에서 실수로 `Y`를 입력해 기존 데이터를 덮어쓰는 경우
 - `pb down` 호출 전에 `pb up` 기록이 없는 경우
 - 이미 열려 있는 포트를 `pb up <target> --port N`으로 다시 지정하는 경우
+- 브라우저에서 프론트가 백엔드 응답을 못 읽을 때 CORS 응답 헤더를 확인하지 않는 경우
 
 ## 운영 메모
 
 - 현재 기준에서 `pb list`, `pb up`, `pb down`, `pb test`, `pb db up/down/reset`, `pb doctor`, `pb gui`가 구현되어 있다.
+- Java Spring Boot 백엔드는 로컬 프론트 개발 서버용 `http://localhost:*`, `http://127.0.0.1:*` CORS origin pattern을 허용한다.
+- NestJS 백엔드는 부트스트랩 단계에서 CORS를 활성화한다.
 - 실행 어댑터와 앱 baseline이 추가되면 이 문서에 구현체별 세부 runbook을 이어서 확장한다.


### PR DESCRIPTION
## Summary
- Fix browser-side frontend API failures caused by missing CORS headers on Java Spring Boot backends.
- Add local frontend origin patterns for all Java post/shop Spring Boot variants.
- Document local frontend/backend CORS behavior in the CLI runbook.

## Fixed
- Added `CorsConfig` to 8 Java Spring Boot backend projects.
- Allows `http://localhost:*` and `http://127.0.0.1:*` origin patterns.
- Allows `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS` with credentials and common headers.
- Keeps existing NestJS `cors: true` setup unchanged.

## Validation
- `gradlew.bat compileJava --no-daemon` for all 4 Gradle Spring Boot projects.
- `mvnw.cmd -q -DskipTests compile` for all 4 Maven Spring Boot projects.
- Restarted `post-java-springboot-gradle-postgresql` on port `8000`.
- `GET http://localhost:8000/api/v1/health` with `Origin: http://localhost:3000` returns `Access-Control-Allow-Origin: http://localhost:3000` and `Access-Control-Allow-Credentials: true`.
- `GET http://localhost:8000/api/v1/boards` with frontend Origin returns 200 and CORS headers.
- `GET http://localhost:8000/api/v1/posts?page=1&limit=5` with frontend Origin returns 200 and CORS headers.
- `OPTIONS http://localhost:8000/api/v1/boards` preflight returns allowed methods and CORS headers.
- `git diff --check`.

Closes #29