### PR TITLE
feat: (#31) post 프론트 게시판 UI와 관리자 화면 분리

### DIFF
--- a/Frontend/web-post/src/app/router.tsx
+++ b/Frontend/web-post/src/app/router.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter } from "react-router-dom";
+import { Navigate, createBrowserRouter } from "react-router-dom";
 import { HomePage } from "../pages/home/page";
 import { LoginPage } from "../pages/login/page";
 import { SignupPage } from "../pages/signup/page";
@@ -17,8 +17,12 @@ export const router = createBrowserRouter([
   { path: "/boards", element: <BoardsPage /> },
   { path: "/post-detail", element: <PostDetailPage /> },
   { path: "/mypage", element: <MypagePage /> },
-  { path: "/admin-dashboard", element: <AdminDashboardPage /> },
-  { path: "/admin-boards", element: <AdminBoardsPage /> },
-  { path: "/admin-posts", element: <AdminPostsPage /> },
-  { path: "/admin-comments", element: <AdminCommentsPage /> },
+  { path: "/admin", element: <AdminDashboardPage /> },
+  { path: "/admin/boards", element: <AdminBoardsPage /> },
+  { path: "/admin/posts", element: <AdminPostsPage /> },
+  { path: "/admin/comments", element: <AdminCommentsPage /> },
+  { path: "/admin-dashboard", element: <Navigate to="/admin" replace /> },
+  { path: "/admin-boards", element: <Navigate to="/admin/boards" replace /> },
+  { path: "/admin-posts", element: <Navigate to="/admin/posts" replace /> },
+  { path: "/admin-comments", element: <Navigate to="/admin/comments" replace /> },
 ]);

--- a/Frontend/web-post/src/app/styles.css
+++ b/Frontend/web-post/src/app/styles.css
@@ -1,16 +1,21 @@
+:root {
+  color: #17202a;
+  background: #f5f7fb;
+  font-family: "Segoe UI", "Noto Sans KR", Arial, sans-serif;
+}
+
 * {
   box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  background: #fff;
-  color: #111;
-  font-family: "Segoe UI", "Noto Sans KR", sans-serif;
+  background: #f5f7fb;
+  color: #17202a;
 }
 
 a {
-  color: #111;
+  color: inherit;
   text-decoration: none;
 }
 
@@ -22,91 +27,164 @@ select {
 }
 
 button {
+  min-height: 38px;
   cursor: pointer;
-  border: 1px solid #111;
-  background: #111;
+  border: 1px solid #1f5eff;
+  border-radius: 6px;
+  background: #1f5eff;
   color: #fff;
-  padding: 8px 12px;
+  padding: 8px 14px;
+  font-weight: 700;
 }
 
 button.secondary {
   background: #fff;
-  color: #111;
+  color: #1f5eff;
+}
+
+button.danger {
+  border-color: #bf2f2f;
+  color: #bf2f2f;
 }
 
 input,
 textarea,
 select {
   width: 100%;
-  border: 1px solid #999;
+  border: 1px solid #c7ced8;
+  border-radius: 6px;
   background: #fff;
-  color: #111;
-  padding: 8px 10px;
+  color: #17202a;
+  padding: 10px 12px;
 }
 
 textarea {
-  min-height: 90px;
+  min-height: 104px;
   resize: vertical;
 }
 
+label {
+  display: grid;
+  gap: 6px;
+  color: #526070;
+  font-size: 13px;
+  font-weight: 700;
+}
+
 .page {
-  max-width: 1120px;
+  max-width: 1240px;
   margin: 0 auto;
-  padding: 28px 20px 56px;
+  padding: 24px 24px 56px;
 }
 
 .nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 10px 16px;
-  padding-bottom: 20px;
-  border-bottom: 1px solid #ddd;
+  align-items: center;
+  gap: 8px;
+  min-height: 56px;
+  border-bottom: 1px solid #dce2ea;
 }
 
-.nav a {
+.brand,
+.admin-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-right: auto;
+  font-weight: 800;
+}
+
+.brand-mark {
+  display: inline-grid;
+  width: 34px;
+  height: 34px;
+  place-items: center;
+  border-radius: 8px;
+  background: #157a6e;
+  color: #fff;
+  font-size: 13px;
+}
+
+.nav a,
+.admin-nav a {
+  border-radius: 6px;
+  color: #526070;
+  padding: 9px 12px;
   font-size: 14px;
-  text-decoration: underline;
+  font-weight: 700;
+}
+
+.nav a.active,
+.nav a:hover,
+.admin-nav a.active,
+.admin-nav a:hover {
+  background: #e8eefc;
+  color: #1f5eff;
 }
 
 .header {
-  padding: 28px 0;
+  padding: 34px 0 24px;
 }
 
 .eyebrow {
+  color: #1f5eff;
   font-size: 12px;
-  letter-spacing: 0.12em;
+  font-weight: 800;
+  letter-spacing: 0;
   text-transform: uppercase;
 }
 
-.header h1 {
+.header h1,
+.admin-header h1 {
   margin: 8px 0;
-  font-size: 34px;
+  font-size: 52px;
+  line-height: 1.08;
 }
 
-.header p {
+.header p,
+.admin-header p {
+  max-width: 720px;
   margin: 0;
-  color: #444;
+  color: #526070;
+  font-size: 17px;
+  line-height: 1.6;
 }
 
-.panel {
-  border: 1px solid #ddd;
-  padding: 20px;
-}
-
-.grid {
+.panel,
+.admin-panel {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+.grid,
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 16px;
 }
 
+.card,
+.metric-card,
+.post-detail-card,
+.comment-item,
+.compose-panel,
+.status-strip,
+.admin-account {
+  border: 1px solid #dce2ea;
+  border-radius: 8px;
+  background: #fff;
+}
+
 .card {
-  border: 1px solid #ddd;
   padding: 16px;
 }
 
-.stack {
+.stack,
+.admin-stack,
+.home-board {
   display: grid;
-  gap: 12px;
+  gap: 16px;
 }
 
 .row {
@@ -116,21 +194,400 @@ textarea {
   align-items: center;
 }
 
+.action-row {
+  margin-top: 16px;
+}
+
 .muted {
-  color: #666;
+  color: #657386;
 }
 
 .error {
-  color: #b00020;
+  color: #bf2f2f;
 }
 
 .success {
-  color: #0b6b2b;
+  color: #157a6e;
+}
+
+.notice {
+  margin: 0;
+  border: 1px solid #f1c6c6;
+  border-radius: 8px;
+  background: #fff6f6;
+  padding: 12px 14px;
+}
+
+.status-strip {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px;
+}
+
+.status-strip div {
+  display: grid;
+  gap: 4px;
+}
+
+.status-strip strong {
+  word-break: break-word;
+}
+
+.metric-card {
+  display: grid;
+  min-height: 132px;
+  align-content: space-between;
+  padding: 18px;
+}
+
+.metric-card span {
+  color: #526070;
+  font-size: 13px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.metric-card strong {
+  display: block;
+  margin: 8px 0;
+  font-size: 30px;
+  line-height: 1.2;
+}
+
+.metric-card small {
+  color: #657386;
+}
+
+.metric-card.accent {
+  border-color: #b7d8d3;
+  background: #eef8f6;
+}
+
+.metric-card.warning {
+  border-color: #f0d2a6;
+  background: #fff8ed;
+}
+
+.board-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 340px) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.board-layout.wide {
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+}
+
+.board-rail,
+.post-feed,
+.detail-main,
+.detail-tools {
+  display: grid;
+  gap: 14px;
+}
+
+.section-heading {
+  display: grid;
+  gap: 4px;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 22px;
+}
+
+.section-heading.split {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.board-list,
+.post-list,
+.comment-list {
+  display: grid;
+  gap: 10px;
+}
+
+.board-item {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid #dce2ea;
+  border-radius: 8px;
+  background: #fff;
+  padding: 14px;
+}
+
+.board-item p {
+  margin: 6px 0 0;
+  color: #657386;
+  line-height: 1.5;
+}
+
+.pill,
+.board-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 28px;
+  border-radius: 999px;
+  padding: 5px 10px;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.pill {
+  border: 1px solid #d0d7e2;
+  background: #fff;
+  color: #526070;
+}
+
+.success-pill {
+  border-color: #a9d4cc;
+  background: #eaf7f4;
+  color: #157a6e;
+}
+
+.board-chip {
+  background: #eef8f6;
+  color: #157a6e;
+}
+
+.post-list,
+.board-table,
+.admin-table {
+  overflow: hidden;
+  border: 1px solid #dce2ea;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.post-row,
+.board-table-row,
+.admin-table-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 16px;
+  align-items: center;
+  min-height: 68px;
+  border-top: 1px solid #edf1f5;
+  padding: 14px 16px;
+}
+
+.post-row:first-child,
+.board-table-row:first-of-type,
+.admin-table-row:first-of-type {
+  border-top: 0;
+}
+
+.post-main {
+  display: grid;
+  gap: 7px;
+  min-width: 0;
+}
+
+.post-main strong {
+  overflow-wrap: anywhere;
+}
+
+.post-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  color: #657386;
+  font-size: 13px;
+}
+
+.post-meta.prominent {
+  margin-top: 18px;
+  font-weight: 800;
+}
+
+.board-table-head,
+.admin-table-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 16px;
+  background: #f0f3f8;
+  color: #526070;
+  padding: 10px 16px;
+  font-size: 12px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.compose-panel {
+  padding: 16px;
+}
+
+.compact-form {
+  gap: 12px;
+}
+
+.detail-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 20px;
+  align-items: start;
+}
+
+.detail-tools {
+  position: sticky;
+  top: 16px;
+}
+
+.post-detail-card,
+.comment-item {
+  padding: 20px;
+}
+
+.post-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.post-detail-card h2 {
+  margin: 18px 0 12px;
+  font-size: 30px;
+  line-height: 1.2;
+}
+
+.post-detail-card p,
+.comment-item p {
+  color: #2d3744;
+  line-height: 1.7;
+}
+
+.empty-state {
+  margin: 0;
+  color: #657386;
+  padding: 18px;
+}
+
+.admin-page {
+  display: grid;
+  grid-template-columns: 252px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.admin-sidebar {
+  position: sticky;
+  top: 0;
+  height: 100vh;
+  border-right: 1px solid #dce2ea;
+  background: #fff;
+  padding: 22px 18px;
+}
+
+.admin-brand {
+  align-items: flex-start;
+  margin: 0 0 28px;
+}
+
+.admin-brand div {
+  display: grid;
+  gap: 2px;
+}
+
+.admin-brand span:last-child {
+  color: #657386;
+  font-size: 13px;
+}
+
+.admin-nav {
+  display: grid;
+  gap: 6px;
+}
+
+.admin-main {
+  padding: 30px 32px 56px;
+}
+
+.admin-header {
+  padding-bottom: 24px;
+}
+
+.admin-form {
+  display: grid;
+  grid-template-columns: minmax(160px, 1fr) minmax(220px, 2fr) 140px auto;
+  gap: 12px;
+  align-items: end;
+  border: 1px solid #dce2ea;
+  border-radius: 8px;
+  background: #fff;
+  padding: 16px;
+}
+
+.admin-account {
+  display: grid;
+  gap: 4px;
+  padding: 14px 16px;
 }
 
 pre {
   overflow: auto;
-  background: #f7f7f7;
-  border: 1px solid #ddd;
+  border: 1px solid #dce2ea;
+  border-radius: 8px;
+  background: #fff;
   padding: 12px;
+}
+
+@media (max-width: 880px) {
+  .page {
+    padding: 18px 16px 40px;
+  }
+
+  .brand {
+    flex-basis: 100%;
+  }
+
+  .board-layout,
+  .board-layout.wide,
+  .detail-layout,
+  .admin-page {
+    grid-template-columns: 1fr;
+  }
+
+  .detail-tools {
+    position: static;
+  }
+
+  .post-row,
+  .board-table-row,
+  .admin-table-row,
+  .admin-form {
+    grid-template-columns: 1fr;
+  }
+
+  .board-table-head,
+  .admin-table-head {
+    display: none;
+  }
+
+  .header h1,
+  .admin-header h1 {
+    font-size: 32px;
+  }
+
+  .admin-sidebar {
+    position: static;
+    height: auto;
+    border-right: 0;
+    border-bottom: 1px solid #dce2ea;
+  }
+
+  .admin-main {
+    padding: 24px 16px 40px;
+  }
 }

--- a/Frontend/web-post/src/entities/post/model.ts
+++ b/Frontend/web-post/src/entities/post/model.ts
@@ -1,6 +1,7 @@
 export interface PostSummary {
   id: number;
   boardId: number;
+  boardName?: string;
   title: string;
   viewCount: number;
   likeCount: number;

--- a/Frontend/web-post/src/features/admin-board-manage/AdminBoardManager.tsx
+++ b/Frontend/web-post/src/features/admin-board-manage/AdminBoardManager.tsx
@@ -21,27 +21,46 @@ export function AdminBoardManager({ boards }: Props) {
   }
 
   return (
-    <>
-      <form className="grid" onSubmit={submit}>
-        <input value={name} onChange={(event) => setName(event.target.value)} />
-        <input value={description} onChange={(event) => setDescription(event.target.value)} />
-        <input type="number" value={displayOrder} onChange={(event) => setDisplayOrder(Number(event.target.value))} />
+    <div className="admin-stack">
+      <form className="admin-form" onSubmit={submit}>
+        <label>
+          Name
+          <input value={name} onChange={(event) => setName(event.target.value)} />
+        </label>
+        <label>
+          Description
+          <input value={description} onChange={(event) => setDescription(event.target.value)} />
+        </label>
+        <label>
+          Display order
+          <input type="number" value={displayOrder} onChange={(event) => setDisplayOrder(Number(event.target.value))} />
+        </label>
         <button type="submit">Create board</button>
       </form>
-      <div className="stack">
+      <div className="admin-table">
+        <div className="admin-table-head">
+          <span>Board</span>
+          <span>Status</span>
+          <span>Actions</span>
+        </div>
         {boards.map((board) => (
-          <div className="card row" key={board.id}>
-            <strong>#{board.id} {board.name}</strong>
-            <span>{board.status}</span>
-            <button className="secondary" type="button" onClick={() => updateBoard(board.id, { status: "HIDDEN" }).then(reload)}>
-              Hide
-            </button>
-            <button className="secondary" type="button" onClick={() => deleteBoard(board.id).then(reload)}>
-              Delete
-            </button>
-          </div>
+          <article className="admin-table-row" key={board.id}>
+            <div>
+              <strong>#{board.id} {board.name}</strong>
+              <p className="muted">{board.description}</p>
+            </div>
+            <span className="pill">{board.status}</span>
+            <div className="row">
+              <button className="secondary" type="button" onClick={() => updateBoard(board.id, { status: "HIDDEN" }).then(reload)}>
+                Hide
+              </button>
+              <button className="secondary danger" type="button" onClick={() => deleteBoard(board.id).then(reload)}>
+                Delete
+              </button>
+            </div>
+          </article>
         ))}
       </div>
-    </>
+    </div>
   );
 }

--- a/Frontend/web-post/src/features/admin-comment-moderate/AdminCommentModeration.tsx
+++ b/Frontend/web-post/src/features/admin-comment-moderate/AdminCommentModeration.tsx
@@ -11,17 +11,28 @@ export function AdminCommentModeration({ comments }: Props) {
   const reload = () => queryClient.invalidateQueries({ queryKey: ["admin-comments"] });
 
   return (
-    <div className="stack">
+    <div className="admin-table">
+      <div className="admin-table-head">
+        <span>Comment</span>
+        <span>Status</span>
+        <span>Actions</span>
+      </div>
       {comments.map((comment) => (
-        <div className="card row" key={comment.id}>
-          <span>#{comment.id} {comment.content}</span>
-          <span>{comment.status}</span>
-          <button type="button" onClick={() => changeCommentStatus(comment.id, "ACTIVE").then(reload)}>Active</button>
-          <button className="secondary" type="button" onClick={() => changeCommentStatus(comment.id, "HIDDEN").then(reload)}>
-            Hidden
-          </button>
-        </div>
+        <article className="admin-table-row" key={comment.id}>
+          <div>
+            <strong>#{comment.id}</strong>
+            <p>{comment.content}</p>
+          </div>
+          <span className="pill">{comment.status}</span>
+          <div className="row">
+            <button type="button" onClick={() => changeCommentStatus(comment.id, "ACTIVE").then(reload)}>Active</button>
+            <button className="secondary" type="button" onClick={() => changeCommentStatus(comment.id, "HIDDEN").then(reload)}>
+              Hidden
+            </button>
+          </div>
+        </article>
       ))}
+      {comments.length === 0 && <p className="empty-state">운영할 댓글이 없습니다.</p>}
     </div>
   );
 }

--- a/Frontend/web-post/src/features/admin-post-moderate/AdminPostModeration.tsx
+++ b/Frontend/web-post/src/features/admin-post-moderate/AdminPostModeration.tsx
@@ -11,17 +11,28 @@ export function AdminPostModeration({ posts }: Props) {
   const reload = () => queryClient.invalidateQueries({ queryKey: ["admin-posts"] });
 
   return (
-    <div className="stack">
+    <div className="admin-table">
+      <div className="admin-table-head">
+        <span>Post</span>
+        <span>Status</span>
+        <span>Actions</span>
+      </div>
       {posts.map((post) => (
-        <div className="card row" key={post.id}>
-          <strong>#{post.id} {post.title}</strong>
-          <span>{post.status}</span>
-          <button type="button" onClick={() => changePostStatus(post.id, "ACTIVE").then(reload)}>Active</button>
-          <button className="secondary" type="button" onClick={() => changePostStatus(post.id, "HIDDEN").then(reload)}>
-            Hidden
-          </button>
-        </div>
+        <article className="admin-table-row" key={post.id}>
+          <div className="post-main">
+            <span className="board-chip">{post.boardName ?? `board ${post.boardId}`}</span>
+            <strong>#{post.id} {post.title}</strong>
+          </div>
+          <span className="pill">{post.status}</span>
+          <div className="row">
+            <button type="button" onClick={() => changePostStatus(post.id, "ACTIVE").then(reload)}>Active</button>
+            <button className="secondary" type="button" onClick={() => changePostStatus(post.id, "HIDDEN").then(reload)}>
+              Hidden
+            </button>
+          </div>
+        </article>
       ))}
+      {posts.length === 0 && <p className="empty-state">운영할 게시글이 없습니다.</p>}
     </div>
   );
 }

--- a/Frontend/web-post/src/features/comment-create/CreateCommentForm.tsx
+++ b/Frontend/web-post/src/features/comment-create/CreateCommentForm.tsx
@@ -20,8 +20,11 @@ export function CreateCommentForm({ postId }: Props) {
   }
 
   return (
-    <form className="stack" onSubmit={submit}>
-      <textarea value={content} onChange={(event) => setContent(event.target.value)} />
+    <form className="stack compact-form" onSubmit={submit}>
+      <label>
+        New comment
+        <textarea value={content} onChange={(event) => setContent(event.target.value)} />
+      </label>
       <button type="submit">Add comment</button>
     </form>
   );

--- a/Frontend/web-post/src/features/post-create/CreatePostForm.tsx
+++ b/Frontend/web-post/src/features/post-create/CreatePostForm.tsx
@@ -18,11 +18,20 @@ export function CreatePostForm() {
   }
 
   return (
-    <form className="stack" onSubmit={submit}>
-      <input type="number" value={boardId} onChange={(event) => setBoardId(Number(event.target.value))} />
-      <input value={title} onChange={(event) => setTitle(event.target.value)} />
-      <textarea value={content} onChange={(event) => setContent(event.target.value)} />
-      <button type="submit">Create</button>
+    <form className="stack compact-form" onSubmit={submit}>
+      <label>
+        Board ID
+        <input type="number" value={boardId} onChange={(event) => setBoardId(Number(event.target.value))} />
+      </label>
+      <label>
+        Title
+        <input value={title} onChange={(event) => setTitle(event.target.value)} />
+      </label>
+      <label>
+        Content
+        <textarea value={content} onChange={(event) => setContent(event.target.value)} />
+      </label>
+      <button type="submit">Create post</button>
       {create.error && <p className="error">{create.error.message}</p>}
     </form>
   );

--- a/Frontend/web-post/src/features/post-edit/UpdatePostTitleForm.tsx
+++ b/Frontend/web-post/src/features/post-edit/UpdatePostTitleForm.tsx
@@ -20,8 +20,11 @@ export function UpdatePostTitleForm({ postId }: Props) {
   }
 
   return (
-    <form className="row" onSubmit={submit}>
-      <input placeholder="New title" value={title} onChange={(event) => setTitle(event.target.value)} />
+    <form className="stack compact-form" onSubmit={submit}>
+      <label>
+        New title
+        <input placeholder="New title" value={title} onChange={(event) => setTitle(event.target.value)} />
+      </label>
       <button type="submit">Update title</button>
     </form>
   );

--- a/Frontend/web-post/src/features/post-like/PostLikeActions.tsx
+++ b/Frontend/web-post/src/features/post-like/PostLikeActions.tsx
@@ -12,7 +12,7 @@ export function PostLikeActions({ postId }: Props) {
   const unlike = useMutation({ mutationFn: () => unlikePost(postId), onSuccess: invalidate });
 
   return (
-    <div className="row">
+    <div className="row action-row">
       <button type="button" onClick={() => like.mutate()}>Like</button>
       <button className="secondary" type="button" onClick={() => unlike.mutate()}>Unlike</button>
     </div>

--- a/Frontend/web-post/src/pages/admin-boards/page.tsx
+++ b/Frontend/web-post/src/pages/admin-boards/page.tsx
@@ -1,10 +1,10 @@
 import { AdminBoardPanel } from "../../widgets/admin-board-panel/AdminBoardPanel";
-import { PageShell } from "../../widgets/app-shell/PageShell";
+import { AdminShell } from "../../widgets/app-shell/AdminShell";
 
 export function AdminBoardsPage() {
   return (
-    <PageShell title="Admin Boards" description="관리자 게시판 CRUD입니다.">
+    <AdminShell title="Board Management" description="게시판 노출 상태와 생성 순서를 관리합니다.">
       <AdminBoardPanel />
-    </PageShell>
+    </AdminShell>
   );
 }

--- a/Frontend/web-post/src/pages/admin-comments/page.tsx
+++ b/Frontend/web-post/src/pages/admin-comments/page.tsx
@@ -1,10 +1,10 @@
 import { AdminCommentPanel } from "../../widgets/admin-comment-panel/AdminCommentPanel";
-import { PageShell } from "../../widgets/app-shell/PageShell";
+import { AdminShell } from "../../widgets/app-shell/AdminShell";
 
 export function AdminCommentsPage() {
   return (
-    <PageShell title="Admin Comments" description="댓글 상태를 운영합니다.">
+    <AdminShell title="Comment Moderation" description="댓글 상태를 빠르게 검토하고 숨김 처리합니다.">
       <AdminCommentPanel />
-    </PageShell>
+    </AdminShell>
   );
 }

--- a/Frontend/web-post/src/pages/admin-dashboard/page.tsx
+++ b/Frontend/web-post/src/pages/admin-dashboard/page.tsx
@@ -1,10 +1,10 @@
 import { AdminDashboardPanel } from "../../widgets/admin-dashboard-panel/AdminDashboardPanel";
-import { PageShell } from "../../widgets/app-shell/PageShell";
+import { AdminShell } from "../../widgets/app-shell/AdminShell";
 
 export function AdminDashboardPage() {
   return (
-    <PageShell title="Admin Dashboard" description="관리자 계정과 게시판 운영 요약입니다.">
+    <AdminShell title="Admin Dashboard" description="관리자 계정과 게시판 운영 요약입니다.">
       <AdminDashboardPanel />
-    </PageShell>
+    </AdminShell>
   );
 }

--- a/Frontend/web-post/src/pages/admin-posts/page.tsx
+++ b/Frontend/web-post/src/pages/admin-posts/page.tsx
@@ -1,10 +1,10 @@
 import { AdminPostPanel } from "../../widgets/admin-post-panel/AdminPostPanel";
-import { PageShell } from "../../widgets/app-shell/PageShell";
+import { AdminShell } from "../../widgets/app-shell/AdminShell";
 
 export function AdminPostsPage() {
   return (
-    <PageShell title="Admin Posts" description="게시글 상태를 운영합니다.">
+    <AdminShell title="Post Moderation" description="게시글 공개 상태와 운영 지표를 확인합니다.">
       <AdminPostPanel />
-    </PageShell>
+    </AdminShell>
   );
 }

--- a/Frontend/web-post/src/pages/boards/page.tsx
+++ b/Frontend/web-post/src/pages/boards/page.tsx
@@ -3,7 +3,7 @@ import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function BoardsPage() {
   return (
-    <PageShell title="Boards" description="게시판 목록, 게시글 목록, 게시글 작성을 확인합니다.">
+    <PageShell title="Boards" description="게시판을 살펴보고 최신 게시글을 목록 중심으로 확인합니다.">
       <BoardPostsPanel />
     </PageShell>
   );

--- a/Frontend/web-post/src/pages/home/page.tsx
+++ b/Frontend/web-post/src/pages/home/page.tsx
@@ -3,7 +3,7 @@ import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function HomePage() {
   return (
-    <PageShell title="Post Home" description="게시판 서비스의 주요 상태와 최신 글을 확인합니다.">
+    <PageShell title="Post Board" description="게시판별 최신 글과 서비스 상태를 한 화면에서 확인합니다.">
       <HomeSummary />
     </PageShell>
   );

--- a/Frontend/web-post/src/pages/post-detail/page.tsx
+++ b/Frontend/web-post/src/pages/post-detail/page.tsx
@@ -3,7 +3,7 @@ import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function PostDetailPage() {
   return (
-    <PageShell title="Post Detail" description="게시글 상세, 댓글, 좋아요를 확인합니다.">
+    <PageShell title="Post Detail" description="게시글 본문, 반응, 댓글 흐름을 확인합니다.">
       <PostDetailPanel />
     </PageShell>
   );

--- a/Frontend/web-post/src/widgets/admin-board-panel/AdminBoardPanel.tsx
+++ b/Frontend/web-post/src/widgets/admin-board-panel/AdminBoardPanel.tsx
@@ -4,5 +4,16 @@ import { AdminBoardManager } from "../../features/admin-board-manage/AdminBoardM
 
 export function AdminBoardPanel() {
   const boards = useQuery({ queryKey: ["boards", "admin"], queryFn: fetchBoards });
-  return <AdminBoardManager boards={boards.data ?? []} />;
+  return (
+    <section className="admin-stack">
+      <div className="section-heading split">
+        <div>
+          <span className="eyebrow">Catalog</span>
+          <h2>게시판 운영</h2>
+        </div>
+        <span className="pill">{boards.data?.length ?? 0} boards</span>
+      </div>
+      <AdminBoardManager boards={boards.data ?? []} />
+    </section>
+  );
 }

--- a/Frontend/web-post/src/widgets/admin-comment-panel/AdminCommentPanel.tsx
+++ b/Frontend/web-post/src/widgets/admin-comment-panel/AdminCommentPanel.tsx
@@ -5,9 +5,15 @@ import { AdminCommentModeration } from "../../features/admin-comment-moderate/Ad
 export function AdminCommentPanel() {
   const comments = useQuery({ queryKey: ["admin-comments"], queryFn: fetchAdminComments });
   return (
-    <>
-      <p className="muted">Total: {comments.data?.meta?.totalCount ?? 0}</p>
+    <section className="admin-stack">
+      <div className="section-heading split">
+        <div>
+          <span className="eyebrow">Queue</span>
+          <h2>댓글 운영</h2>
+        </div>
+        <span className="pill">{comments.data?.meta?.totalCount ?? 0} comments</span>
+      </div>
       <AdminCommentModeration comments={comments.data?.data ?? []} />
-    </>
+    </section>
   );
 }

--- a/Frontend/web-post/src/widgets/admin-dashboard-panel/AdminDashboardPanel.tsx
+++ b/Frontend/web-post/src/widgets/admin-dashboard-panel/AdminDashboardPanel.tsx
@@ -7,18 +7,43 @@ export function AdminDashboardPanel() {
   const dashboard = useQuery({ queryKey: ["admin-dashboard"], queryFn: fetchAdminDashboard, retry: false });
 
   return (
-    <>
-      {me.error && <p className="error">Login as admin first.</p>}
-      {me.data && <p>Admin: {me.data.email}</p>}
-      {dashboard.data && (
-        <div className="grid">
-          <div className="card">Boards: {dashboard.data.boardCount}</div>
-          <div className="card">Posts: {dashboard.data.postCount}</div>
-          <div className="card">Comments: {dashboard.data.commentCount}</div>
-          <div className="card">Hidden posts: {dashboard.data.hiddenPostCount}</div>
-          <div className="card">Hidden comments: {dashboard.data.hiddenCommentCount}</div>
+    <div className="admin-stack">
+      {me.error && <p className="error notice">Login as admin first.</p>}
+      {me.data && (
+        <div className="admin-account">
+          <span className="eyebrow">Signed in</span>
+          <strong>{me.data.email}</strong>
         </div>
       )}
-    </>
+      {dashboard.data && (
+        <div className="metric-grid admin-metrics">
+          <div className="metric-card">
+            <span>Boards</span>
+            <strong>{dashboard.data.boardCount}</strong>
+            <small>managed board groups</small>
+          </div>
+          <div className="metric-card">
+            <span>Posts</span>
+            <strong>{dashboard.data.postCount}</strong>
+            <small>published and hidden</small>
+          </div>
+          <div className="metric-card">
+            <span>Comments</span>
+            <strong>{dashboard.data.commentCount}</strong>
+            <small>thread replies</small>
+          </div>
+          <div className="metric-card warning">
+            <span>Hidden posts</span>
+            <strong>{dashboard.data.hiddenPostCount}</strong>
+            <small>moderation queue</small>
+          </div>
+          <div className="metric-card warning">
+            <span>Hidden comments</span>
+            <strong>{dashboard.data.hiddenCommentCount}</strong>
+            <small>comment moderation</small>
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/Frontend/web-post/src/widgets/admin-post-panel/AdminPostPanel.tsx
+++ b/Frontend/web-post/src/widgets/admin-post-panel/AdminPostPanel.tsx
@@ -5,9 +5,15 @@ import { AdminPostModeration } from "../../features/admin-post-moderate/AdminPos
 export function AdminPostPanel() {
   const posts = useQuery({ queryKey: ["admin-posts"], queryFn: fetchAdminPosts });
   return (
-    <>
-      <p className="muted">Total: {posts.data?.meta?.totalCount ?? 0}</p>
+    <section className="admin-stack">
+      <div className="section-heading split">
+        <div>
+          <span className="eyebrow">Queue</span>
+          <h2>게시글 운영</h2>
+        </div>
+        <span className="pill">{posts.data?.meta?.totalCount ?? 0} posts</span>
+      </div>
       <AdminPostModeration posts={posts.data?.data ?? []} />
-    </>
+    </section>
   );
 }

--- a/Frontend/web-post/src/widgets/app-shell/AdminShell.tsx
+++ b/Frontend/web-post/src/widgets/app-shell/AdminShell.tsx
@@ -1,0 +1,47 @@
+import { PropsWithChildren } from "react";
+import { NavLink } from "react-router-dom";
+
+interface Props extends PropsWithChildren {
+  title: string;
+  description: string;
+}
+
+const adminLinks = [
+  ["/admin", "Dashboard"],
+  ["/admin/boards", "Boards"],
+  ["/admin/posts", "Posts"],
+  ["/admin/comments", "Comments"],
+  ["/login", "Login"],
+  ["/boards", "Public Board"],
+];
+
+export function AdminShell({ title, description, children }: Props) {
+  return (
+    <main className="admin-page">
+      <aside className="admin-sidebar">
+        <div className="admin-brand">
+          <span className="brand-mark">PB</span>
+          <div>
+            <strong>Post Admin</strong>
+            <span>Operations</span>
+          </div>
+        </div>
+        <nav className="admin-nav" aria-label="Post admin navigation">
+          {adminLinks.map(([to, label]) => (
+            <NavLink key={to} to={to} end={to === "/admin"} className={({ isActive }) => (isActive ? "active" : undefined)}>
+              {label}
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+      <section className="admin-main">
+        <header className="admin-header">
+          <div className="eyebrow">Project-Bible Post Admin</div>
+          <h1>{title}</h1>
+          <p>{description}</p>
+        </header>
+        <div className="admin-panel">{children}</div>
+      </section>
+    </main>
+  );
+}

--- a/Frontend/web-post/src/widgets/app-shell/PageShell.tsx
+++ b/Frontend/web-post/src/widgets/app-shell/PageShell.tsx
@@ -1,36 +1,38 @@
 import { PropsWithChildren } from "react";
-import { Link } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 
 interface Props extends PropsWithChildren {
   title: string;
   description: string;
+  kicker?: string;
 }
 
 const links = [
   ["/", "Home"],
-  ["/login", "Login"],
-  ["/signup", "Signup"],
   ["/boards", "Boards"],
   ["/post-detail", "Post Detail"],
   ["/mypage", "My Page"],
-  ["/admin-dashboard", "Admin"],
-  ["/admin-boards", "Admin Boards"],
-  ["/admin-posts", "Admin Posts"],
-  ["/admin-comments", "Admin Comments"],
+  ["/login", "Login"],
+  ["/signup", "Signup"],
+  ["/admin", "Admin"],
 ];
 
-export function PageShell({ title, description, children }: Props) {
+export function PageShell({ title, description, kicker = "Project-Bible Post", children }: Props) {
   return (
     <main className="page">
-      <nav className="nav">
+      <nav className="nav" aria-label="Post navigation">
+        <div className="brand">
+          <span className="brand-mark">PB</span>
+          <span>Post Board</span>
+        </div>
         {links.map(([to, label]) => (
-          <Link key={to} to={to}>
+          <NavLink key={to} to={to} className={({ isActive }) => (isActive ? "active" : undefined)}>
             {label}
-          </Link>
+          </NavLink>
         ))}
       </nav>
       <header className="header">
-        <div className="eyebrow">Project-Bible Post</div>
+        <div className="eyebrow">{kicker}</div>
         <h1>{title}</h1>
         <p>{description}</p>
       </header>

--- a/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
+++ b/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
@@ -6,38 +6,73 @@ import { CreatePostForm } from "../../features/post-create/CreatePostForm";
 export function BoardPostsPanel() {
   const boards = useQuery({ queryKey: ["boards"], queryFn: fetchBoards });
   const posts = useQuery({ queryKey: ["posts"], queryFn: () => fetchPosts({ page: 1, limit: 20, sort: "latest" }) });
+  const postRows = posts.data?.data ?? [];
 
   return (
-    <>
-      <div className="grid">
-        <section>
-          <h2>Boards</h2>
-          <div className="stack">
-            {(boards.data ?? []).map((board) => (
-              <div className="card" key={board.id}>
+    <div className="board-layout wide">
+      <aside className="board-rail">
+        <div className="section-heading">
+          <span className="eyebrow">Channel</span>
+          <h2>게시판 목록</h2>
+        </div>
+        <div className="board-list">
+          {boards.isLoading && <p className="muted">게시판을 불러오는 중입니다.</p>}
+          {boards.error && <p className="error">게시판을 불러오지 못했습니다.</p>}
+          {(boards.data ?? []).map((board) => (
+            <article className="board-item" key={board.id}>
+              <div>
                 <strong>{board.name}</strong>
                 <p>{board.description}</p>
-                <p className="muted">#{board.id} / {board.status}</p>
               </div>
-            ))}
+              <span className="pill">{board.status}</span>
+            </article>
+          ))}
+        </div>
+
+        <section className="compose-panel">
+          <div className="section-heading">
+            <span className="eyebrow">Compose</span>
+            <h2>글 작성</h2>
           </div>
-        </section>
-        <section>
-          <h2>Create post</h2>
           <CreatePostForm />
         </section>
-      </div>
-      <h2>Posts</h2>
-      <div className="stack">
-        {(posts.data?.data ?? []).map((post) => (
-          <div className="card" key={post.id}>
-            <strong>#{post.id} {post.title}</strong>
-            <p className="muted">
-              board {post.boardId} / views {post.viewCount} / likes {post.likeCount} / comments {post.commentCount} / {post.status}
-            </p>
+      </aside>
+
+      <section className="post-feed">
+        <div className="section-heading split">
+          <div>
+            <span className="eyebrow">Latest</span>
+            <h2>전체 게시글</h2>
           </div>
-        ))}
-      </div>
-    </>
+          <span className="pill">{posts.data?.meta?.totalCount ?? 0} posts</span>
+        </div>
+        <div className="board-table">
+          <div className="board-table-head">
+            <span>게시글</span>
+            <span>반응</span>
+            <span>상태</span>
+          </div>
+          {posts.isLoading && <p className="empty-state">게시글을 불러오는 중입니다.</p>}
+          {posts.error && <p className="error">게시글을 불러오지 못했습니다.</p>}
+          {postRows.map((post) => (
+            <article className="board-table-row" key={post.id}>
+              <div className="post-main">
+                <span className="board-chip">{post.boardName ?? `board ${post.boardId}`}</span>
+                <strong>
+                  #{post.id} {post.title}
+                </strong>
+              </div>
+              <div className="post-meta">
+                <span>{post.viewCount} views</span>
+                <span>{post.likeCount} likes</span>
+                <span>{post.commentCount} comments</span>
+              </div>
+              <span className="pill">{post.status}</span>
+            </article>
+          ))}
+          {postRows.length === 0 && !posts.isLoading && <p className="empty-state">아직 표시할 게시글이 없습니다.</p>}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
+++ b/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
@@ -8,35 +8,82 @@ export function HomeSummary() {
   const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
   const boards = useQuery({ queryKey: ["boards", "home"], queryFn: fetchBoards });
   const posts = useQuery({ queryKey: ["posts", "home"], queryFn: () => fetchPosts({ page: 1, limit: 5 }) });
+  const healthLabel = health.isLoading ? "Checking" : health.data ? `${health.data.status} / ${health.data.service}` : "Unavailable";
+  const recentPosts = posts.data?.data ?? [];
 
   return (
-    <>
-      <div className="grid">
-        <div className="card">
-          <h2>API</h2>
-          <p className="muted">{env.apiBaseUrl}</p>
-          <p>{health.isLoading ? "Checking..." : `${health.data?.status} / ${health.data?.service}`}</p>
+    <div className="home-board">
+      <div className="status-strip">
+        <div>
+          <span className="eyebrow">API Endpoint</span>
+          <strong>{env.apiBaseUrl}</strong>
         </div>
-        <div className="card">
-          <h2>Boards</h2>
-          <p>{boards.data?.length ?? 0} boards loaded</p>
+        <span className={health.data?.status === "UP" ? "pill success-pill" : "pill"}>{healthLabel}</span>
+      </div>
+
+      <div className="metric-grid">
+        <div className="metric-card">
+          <span>Boards</span>
+          <strong>{boards.data?.length ?? 0}</strong>
+          <small>active board groups</small>
         </div>
-        <div className="card">
-          <h2>Posts</h2>
-          <p>{posts.data?.meta?.totalCount ?? 0} total posts</p>
+        <div className="metric-card">
+          <span>Posts</span>
+          <strong>{posts.data?.meta?.totalCount ?? 0}</strong>
+          <small>total discussion threads</small>
+        </div>
+        <div className="metric-card accent">
+          <span>Latest</span>
+          <strong>{recentPosts[0]?.title ?? "No posts"}</strong>
+          <small>{recentPosts[0]?.boardName ?? `board ${recentPosts[0]?.boardId ?? "-"}`}</small>
         </div>
       </div>
-      <h2>Recent posts</h2>
-      <div className="stack">
-        {(posts.data?.data ?? []).map((post) => (
-          <div className="card" key={post.id}>
-            <strong>{post.title}</strong>
-            <p className="muted">
-              views {post.viewCount} / likes {post.likeCount} / comments {post.commentCount}
-            </p>
+
+      <div className="board-layout">
+        <section className="board-rail">
+          <div className="section-heading">
+            <span className="eyebrow">Boards</span>
+            <h2>게시판</h2>
           </div>
-        ))}
+          <div className="board-list">
+            {(boards.data ?? []).map((board) => (
+              <article className="board-item" key={board.id}>
+                <div>
+                  <strong>{board.name}</strong>
+                  <p>{board.description}</p>
+                </div>
+                <span className="pill">{board.status}</span>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="post-feed">
+          <div className="section-heading split">
+            <div>
+              <span className="eyebrow">Recent posts</span>
+              <h2>최신 글</h2>
+            </div>
+            <span className="muted">{posts.data?.meta?.totalCount ?? 0} total</span>
+          </div>
+          <div className="post-list">
+            {recentPosts.map((post) => (
+              <article className="post-row" key={post.id}>
+                <div className="post-main">
+                  <span className="board-chip">{post.boardName ?? `board ${post.boardId}`}</span>
+                  <strong>{post.title}</strong>
+                </div>
+                <div className="post-meta">
+                  <span>{post.viewCount} views</span>
+                  <span>{post.likeCount} likes</span>
+                  <span>{post.commentCount} comments</span>
+                </div>
+              </article>
+            ))}
+            {recentPosts.length === 0 && <p className="empty-state">아직 표시할 게시글이 없습니다.</p>}
+          </div>
+        </section>
       </div>
-    </>
+    </div>
   );
 }

--- a/Frontend/web-post/src/widgets/post-detail-panel/PostDetailPanel.tsx
+++ b/Frontend/web-post/src/widgets/post-detail-panel/PostDetailPanel.tsx
@@ -13,31 +13,56 @@ export function PostDetailPanel() {
   const comments = useQuery({ queryKey: ["comments", postId], queryFn: () => fetchComments(postId) });
 
   return (
-    <div className="stack">
-      <label>
-        Post ID
-        <input type="number" value={postId} onChange={(event) => setPostId(Number(event.target.value))} />
-      </label>
-      {detail.data && (
-        <div className="card">
-          <h2>{detail.data.title}</h2>
-          <p>{detail.data.content}</p>
-          <p className="muted">
-            views {detail.data.viewCount} / likes {detail.data.likeCount} / comments {detail.data.commentCount}
-          </p>
-          <PostLikeActions postId={postId} />
+    <div className="detail-layout">
+      <aside className="detail-tools">
+        <label>
+          Post ID
+          <input type="number" value={postId} onChange={(event) => setPostId(Number(event.target.value))} />
+        </label>
+        <UpdatePostTitleForm postId={postId} />
+        <CreateCommentForm postId={postId} />
+      </aside>
+
+      <section className="detail-main">
+        {detail.data && (
+          <article className="post-detail-card">
+            <div className="post-detail-header">
+              <span className="board-chip">{detail.data.boardName ?? `board ${detail.data.boardId}`}</span>
+              <span className="pill">{detail.data.status}</span>
+            </div>
+            <h2>{detail.data.title}</h2>
+            <p>{detail.data.content}</p>
+            <div className="post-meta prominent">
+              <span>{detail.data.viewCount} views</span>
+              <span>{detail.data.likeCount} likes</span>
+              <span>{detail.data.commentCount} comments</span>
+            </div>
+            <PostLikeActions postId={postId} />
+          </article>
+        )}
+        {!detail.data && detail.isLoading && <p className="empty-state">게시글을 불러오는 중입니다.</p>}
+        {detail.error && <p className="error">게시글을 불러오지 못했습니다.</p>}
+
+        <div className="section-heading split">
+          <div>
+            <span className="eyebrow">Thread</span>
+            <h2>댓글</h2>
+          </div>
+          <span className="pill">{comments.data?.meta?.totalCount ?? 0} comments</span>
         </div>
-      )}
-      <UpdatePostTitleForm postId={postId} />
-      <CreateCommentForm postId={postId} />
-      <h2>Comments</h2>
-      {(comments.data?.data ?? []).map((item) => (
-        <div className="card row" key={item.id}>
-          <span>{item.content}</span>
-          <span className="muted">{item.status}</span>
-          <DeleteCommentButton commentId={item.id} postId={postId} />
+        <div className="comment-list">
+          {(comments.data?.data ?? []).map((item) => (
+            <article className="comment-item" key={item.id}>
+              <p>{item.content}</p>
+              <div className="row">
+                <span className="muted">#{item.id} / {item.status}</span>
+                <DeleteCommentButton commentId={item.id} postId={postId} />
+              </div>
+            </article>
+          ))}
+          {comments.data?.data.length === 0 && <p className="empty-state">아직 댓글이 없습니다.</p>}
         </div>
-      ))}
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Refresh `web-post` into a board-style UI with clearer public navigation, status cards, board rail, post feed, and detail layout.
- Split admin pages into a dedicated `/admin` layout with its own sidebar navigation.
- Keep legacy admin URLs as redirects to the new `/admin/*` routes.

## Implemented
- Added `AdminShell` for separated post admin pages.
- Reworked public `PageShell` navigation to show public board links plus a single Admin entry.
- Redesigned Home, Boards, Post Detail, create post, comment, like, and admin moderation surfaces.
- Added `boardName` to post models for board-style labels when the API returns it.
- Replaced the flat baseline CSS with responsive board/admin layout styles.

## Validation
- `npm run build`
- `npm run test`
- `git diff --check`
- Playwright screenshot smoke checks for desktop `/`, `/boards`, `/post-detail`, `/admin`, `/admin/posts`, `/admin/boards`
- Playwright screenshot smoke checks for mobile `/`, `/boards`, `/admin`

Closes #31