### PR TITLE
feat: (#33) post 프론트 커뮤니티형 게시판 목록 개선

### DIFF
--- a/Frontend/web-post/src/app/styles.css
+++ b/Frontend/web-post/src/app/styles.css
@@ -72,7 +72,7 @@ label {
 }
 
 .page {
-  max-width: 1240px;
+  max-width: 1360px;
   margin: 0 auto;
   padding: 24px 24px 56px;
 }
@@ -124,7 +124,7 @@ label {
 }
 
 .header {
-  padding: 34px 0 24px;
+  padding: 24px 0 18px;
 }
 
 .eyebrow {
@@ -138,7 +138,7 @@ label {
 .header h1,
 .admin-header h1 {
   margin: 8px 0;
-  font-size: 52px;
+  font-size: 40px;
   line-height: 1.08;
 }
 
@@ -475,6 +475,278 @@ label {
   padding: 18px;
 }
 
+.community-board {
+  display: grid;
+  gap: 12px;
+}
+
+.community-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid #cfd7e3;
+  border-radius: 8px;
+  background: #fff;
+  padding: 10px;
+}
+
+.board-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.board-tabs button {
+  min-height: 32px;
+  border-color: #d5dce7;
+  background: #fff;
+  color: #334155;
+  padding: 6px 11px;
+  font-size: 13px;
+}
+
+.board-tabs button.active {
+  border-color: #1f5eff;
+  background: #1f5eff;
+  color: #fff;
+}
+
+.board-search {
+  display: grid;
+  grid-template-columns: minmax(180px, 260px) auto;
+  gap: 6px;
+}
+
+.board-search input {
+  min-height: 32px;
+  padding: 6px 10px;
+}
+
+.board-search button {
+  min-height: 32px;
+  padding: 6px 12px;
+}
+
+.community-layout {
+  display: grid;
+  grid-template-columns: 220px minmax(0, 1fr) 260px;
+  gap: 12px;
+  align-items: start;
+}
+
+.board-page-layout {
+  grid-template-columns: 240px minmax(0, 1fr) 250px;
+}
+
+.community-left,
+.community-main,
+.community-right {
+  display: grid;
+  gap: 12px;
+}
+
+.forum-box,
+.community-main {
+  border: 1px solid #cfd7e3;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.forum-box {
+  padding: 12px;
+}
+
+.forum-box h2,
+.forum-board-head h2 {
+  margin: 0;
+  font-size: 17px;
+}
+
+.forum-box.compact {
+  display: grid;
+  gap: 10px;
+}
+
+.api-line {
+  overflow-wrap: anywhere;
+  margin: 0;
+  color: #526070;
+  font-size: 13px;
+}
+
+.category-list {
+  display: grid;
+  gap: 4px;
+  margin-top: 10px;
+}
+
+.category-list button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 34px;
+  border: 0;
+  border-radius: 6px;
+  background: #f5f7fb;
+  color: #263445;
+  padding: 7px 9px;
+  text-align: left;
+}
+
+.category-list button:hover {
+  background: #e8eefc;
+  color: #1f5eff;
+}
+
+.category-list small {
+  overflow: hidden;
+  color: #657386;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.forum-board-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid #dce2ea;
+  padding: 12px 14px;
+}
+
+.forum-stats {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  color: #526070;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.forum-stats button {
+  min-height: 32px;
+  padding: 6px 12px;
+}
+
+.forum-table {
+  overflow: hidden;
+}
+
+.forum-table-head,
+.forum-row {
+  display: grid;
+  grid-template-columns: 64px minmax(260px, 1fr) 120px 82px 72px 72px;
+  align-items: center;
+  gap: 10px;
+}
+
+.forum-table-head {
+  min-height: 34px;
+  border-bottom: 1px solid #dce2ea;
+  background: #f0f3f8;
+  color: #526070;
+  padding: 0 14px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.forum-row {
+  min-height: 44px;
+  border-bottom: 1px solid #edf1f5;
+  padding: 7px 14px;
+  color: #334155;
+  font-size: 13px;
+}
+
+.forum-row:last-child {
+  border-bottom: 0;
+}
+
+.forum-row:hover {
+  background: #f8fbff;
+}
+
+.forum-no,
+.forum-author {
+  color: #657386;
+}
+
+.forum-title-cell {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+
+.forum-title-cell strong {
+  overflow: hidden;
+  color: #111827;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.comment-badge {
+  color: #d9480f;
+  font-weight: 800;
+}
+
+.ranking-list {
+  display: grid;
+  gap: 8px;
+  margin: 10px 0 0;
+  padding-left: 20px;
+}
+
+.ranking-list li {
+  padding-left: 2px;
+}
+
+.ranking-list span {
+  display: block;
+  overflow: hidden;
+  color: #111827;
+  font-size: 13px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ranking-list small {
+  color: #657386;
+}
+
+.mini-stat {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-top: 1px solid #edf1f5;
+  padding-top: 9px;
+}
+
+.mini-stat:first-of-type {
+  border-top: 0;
+  padding-top: 0;
+}
+
+.mini-stat span {
+  color: #657386;
+  font-size: 13px;
+}
+
+.mini-stat strong {
+  color: #111827;
+  font-size: 20px;
+}
+
+.write-box .compact-form {
+  margin-top: 10px;
+}
+
 .admin-page {
   display: grid;
   grid-template-columns: 252px minmax(0, 1fr);
@@ -555,6 +827,8 @@ pre {
   .board-layout,
   .board-layout.wide,
   .detail-layout,
+  .community-layout,
+  .board-page-layout,
   .admin-page {
     grid-template-columns: 1fr;
   }
@@ -571,8 +845,57 @@ pre {
   }
 
   .board-table-head,
-  .admin-table-head {
+  .admin-table-head,
+  .forum-table-head {
     display: none;
+  }
+
+  .community-toolbar,
+  .forum-board-head {
+    align-items: stretch;
+  }
+
+  .board-search {
+    grid-template-columns: 1fr auto;
+    width: 100%;
+  }
+
+  .forum-row {
+    grid-template-columns: 1fr;
+    gap: 6px;
+    min-height: 0;
+    padding: 12px 14px;
+  }
+
+  .forum-no::before {
+    content: "No. ";
+  }
+
+  .forum-title-cell {
+    flex-wrap: wrap;
+  }
+
+  .forum-title-cell strong {
+    flex-basis: 100%;
+    white-space: normal;
+  }
+
+  .forum-author,
+  .forum-date,
+  .forum-views,
+  .forum-likes {
+    display: inline-flex;
+    gap: 6px;
+  }
+
+  .forum-author::before,
+  .forum-date::before,
+  .forum-views::before,
+  .forum-likes::before {
+    content: attr(data-label);
+    min-width: 42px;
+    color: #657386;
+    font-weight: 800;
   }
 
   .header h1,

--- a/Frontend/web-post/src/app/styles.css
+++ b/Frontend/web-post/src/app/styles.css
@@ -747,6 +747,222 @@ label {
   margin-top: 10px;
 }
 
+.gallery-headline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid #b9c6e2;
+  border-top: 3px solid #2f5fd0;
+  border-radius: 2px;
+  background: #fff;
+  padding: 10px 12px;
+}
+
+.gallery-headline h2 {
+  margin: 2px 0 3px;
+  color: #18233f;
+  font-size: 22px;
+}
+
+.gallery-headline p {
+  margin: 0;
+  color: #526070;
+  font-size: 13px;
+}
+
+.gallery-label {
+  color: #2f5fd0;
+  font-size: 11px;
+  font-weight: 900;
+  text-transform: uppercase;
+}
+
+.gallery-counts {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.gallery-counts span {
+  border: 1px solid #d5dce7;
+  background: #f6f8fc;
+  padding: 5px 8px;
+  color: #526070;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.gallery-counts strong {
+  color: #183b8f;
+}
+
+.community-board .community-toolbar,
+.community-board .forum-box,
+.community-board .community-main {
+  border-radius: 2px;
+}
+
+.community-board .community-toolbar {
+  border-color: #b9c6e2;
+  background: #f8faff;
+  padding: 6px;
+}
+
+.community-board .board-tabs {
+  gap: 3px;
+}
+
+.community-board .board-tabs button {
+  min-height: 28px;
+  border-radius: 2px;
+  padding: 4px 10px;
+  font-size: 12px;
+}
+
+.community-board .board-tabs button.active {
+  border-color: #2f5fd0;
+  background: #2f5fd0;
+}
+
+.community-board .board-search {
+  grid-template-columns: minmax(180px, 250px) 54px;
+}
+
+.community-board .board-search input,
+.community-board .board-search button {
+  min-height: 29px;
+  border-radius: 2px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.community-board .community-layout {
+  grid-template-columns: 180px minmax(0, 1fr) 220px;
+  gap: 8px;
+}
+
+.community-board .board-page-layout {
+  grid-template-columns: 200px minmax(0, 1fr) 220px;
+}
+
+.community-board .forum-box {
+  border-color: #c8d1e1;
+  padding: 9px;
+}
+
+.community-board .forum-box h2,
+.community-board .forum-board-head h2 {
+  color: #111827;
+  font-size: 15px;
+}
+
+.community-board .category-list {
+  gap: 2px;
+  margin-top: 8px;
+}
+
+.community-board .category-list button {
+  min-height: 29px;
+  border-radius: 2px;
+  background: #f0f3f8;
+  padding: 5px 8px;
+  font-size: 12px;
+}
+
+.community-board .forum-board-head {
+  min-height: 49px;
+  border-bottom-color: #bcc8dd;
+  background: #fff;
+  padding: 9px 12px;
+}
+
+.community-board .forum-stats {
+  font-size: 12px;
+}
+
+.community-board .forum-stats button {
+  min-height: 28px;
+  border-radius: 2px;
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
+.community-board .forum-table-head,
+.community-board .forum-row {
+  grid-template-columns: 46px minmax(220px, 1fr) 104px 66px 50px 50px;
+  gap: 8px;
+}
+
+.community-board .forum-table-head {
+  min-height: 31px;
+  border-top: 1px solid #eef2f7;
+  border-bottom-color: #c8d1e1;
+  background: #edf1f7;
+  padding: 0 10px;
+  font-size: 11px;
+}
+
+.community-board .forum-row {
+  min-height: 34px;
+  padding: 5px 10px;
+  font-size: 12px;
+}
+
+.community-board .notice-row {
+  background: #fbfcff;
+  font-weight: 800;
+}
+
+.community-board .forum-title-cell {
+  gap: 5px;
+}
+
+.community-board .board-chip,
+.notice-chip {
+  min-height: 20px;
+  border-radius: 2px;
+  padding: 2px 6px;
+  font-size: 11px;
+  line-height: 1.2;
+}
+
+.community-board .board-chip {
+  background: #e8f3f1;
+}
+
+.notice-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  background: #e9eefc;
+  color: #2f5fd0;
+  font-weight: 900;
+}
+
+.community-board .comment-badge {
+  font-size: 11px;
+}
+
+.community-board .ranking-list {
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.community-board .ranking-list span {
+  font-size: 12px;
+}
+
+.community-board .ranking-list small,
+.community-board .mini-stat span {
+  font-size: 12px;
+}
+
+.community-board .mini-stat strong {
+  font-size: 18px;
+}
+
 .admin-page {
   display: grid;
   grid-template-columns: 252px minmax(0, 1fr);
@@ -855,9 +1071,57 @@ pre {
     align-items: stretch;
   }
 
+  .gallery-headline {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .gallery-counts {
+    justify-content: flex-start;
+  }
+
+  .community-board .community-layout,
+  .community-board .board-page-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .community-board .community-main {
+    order: 1;
+  }
+
+  .community-board .community-left {
+    order: 2;
+  }
+
+  .community-board .community-right {
+    order: 3;
+  }
+
+  .community-board .community-toolbar {
+    gap: 8px;
+  }
+
+  .community-board .board-tabs {
+    width: 100%;
+  }
+
+  .community-board .board-tabs button {
+    flex: 1 1 auto;
+  }
+
   .board-search {
     grid-template-columns: 1fr auto;
     width: 100%;
+  }
+
+  .community-board .board-search {
+    grid-template-columns: minmax(0, 1fr) 60px;
+    width: 100%;
+  }
+
+  .community-board .forum-table-head,
+  .community-board .forum-row {
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .forum-row {

--- a/Frontend/web-post/src/app/styles.css
+++ b/Frontend/web-post/src/app/styles.css
@@ -1,6 +1,6 @@
 :root {
   color: #17202a;
-  background: #f5f7fb;
+  background: #fff;
   font-family: "Segoe UI", "Noto Sans KR", Arial, sans-serif;
 }
 
@@ -10,7 +10,7 @@
 
 body {
   margin: 0;
-  background: #f5f7fb;
+  background: #fff;
   color: #17202a;
 }
 
@@ -77,6 +77,70 @@ label {
   padding: 24px 24px 56px;
 }
 
+.dc-page {
+  max-width: none;
+  padding: 0 0 44px;
+}
+
+.masthead {
+  background: #fff;
+  padding: 24px 0 18px;
+}
+
+.masthead-inner {
+  display: grid;
+  grid-template-columns: 230px minmax(300px, 380px) 1fr;
+  align-items: center;
+  gap: 20px;
+  max-width: 980px;
+  margin: 0 auto;
+}
+
+.wordmark {
+  color: #b8bfd6;
+  font-size: 22px;
+  font-style: italic;
+  font-weight: 800;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.global-search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 48px;
+  border: 3px solid #33458f;
+  background: #33458f;
+}
+
+.global-search input {
+  min-height: 34px;
+  border: 0;
+  border-radius: 0;
+  padding: 0 12px;
+  font-size: 13px;
+}
+
+.global-search button {
+  min-height: 34px;
+  border: 0;
+  border-radius: 0;
+  background: #33458f;
+  color: #fff;
+  padding: 0;
+  font-size: 12px;
+}
+
+.masthead-count {
+  justify-self: end;
+  color: #33458f;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.masthead-count strong {
+  color: #d6435b;
+}
+
 .nav {
   display: flex;
   flex-wrap: wrap;
@@ -84,6 +148,25 @@ label {
   gap: 8px;
   min-height: 56px;
   border-bottom: 1px solid #dce2ea;
+}
+
+.dc-page .nav {
+  min-height: 36px;
+  border: 0;
+  background: #33458f;
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  max-width: 980px;
+  min-height: 36px;
+  margin: 0 auto;
+}
+
+.nav-spacer {
+  flex: 1;
 }
 
 .brand,
@@ -115,6 +198,22 @@ label {
   font-weight: 700;
 }
 
+.dc-page .nav a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  border-radius: 0;
+  color: #fff;
+  padding: 0 14px;
+  font-size: 13px;
+}
+
+.dc-page .nav a.active,
+.dc-page .nav a:hover {
+  background: #263775;
+  color: #fff;
+}
+
 .nav a.active,
 .nav a:hover,
 .admin-nav a.active,
@@ -125,6 +224,41 @@ label {
 
 .header {
   padding: 24px 0 18px;
+}
+
+.recent-bar,
+.gallery-page-header,
+.dc-page .panel {
+  max-width: 980px;
+  margin-right: auto;
+  margin-left: auto;
+}
+
+.recent-bar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 32px;
+  border: 1px solid #d8d8d8;
+  border-top: 0;
+  background: #f7f7f7;
+  padding: 0 10px;
+  color: #4b5570;
+  font-size: 12px;
+}
+
+.recent-button {
+  min-height: 22px;
+  border: 1px solid #c3c7d5;
+  border-radius: 0;
+  background: #fff;
+  color: #33458f;
+  padding: 2px 8px;
+  font-size: 12px;
+}
+
+.gallery-page-header {
+  display: none;
 }
 
 .eyebrow {
@@ -569,13 +703,6 @@ label {
   gap: 10px;
 }
 
-.api-line {
-  overflow-wrap: anywhere;
-  margin: 0;
-  color: #526070;
-  font-size: 13px;
-}
-
 .category-list {
   display: grid;
   gap: 4px;
@@ -963,6 +1090,340 @@ label {
   font-size: 18px;
 }
 
+.dc-page .community-board {
+  gap: 10px;
+  color: #1d2438;
+  font-size: 12px;
+}
+
+.dc-page .community-toolbar {
+  border: 0;
+  border-bottom: 2px solid #33458f;
+  background: #fff;
+  padding: 10px 0 6px;
+}
+
+.dc-page .board-tabs {
+  align-items: center;
+}
+
+.dc-page .board-tabs button {
+  min-height: 24px;
+  border: 0;
+  background: #fff;
+  color: #27346e;
+  padding: 2px 5px;
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.dc-page .board-tabs button.active {
+  background: #fff;
+  color: #27346e;
+}
+
+.dc-page .board-tabs button.active::after {
+  content: "";
+  display: inline-block;
+  width: 9px;
+  height: 9px;
+  margin-left: 4px;
+  background: #e51d2a;
+  transform: rotate(-35deg);
+}
+
+.dc-page .board-search {
+  grid-template-columns: minmax(160px, 230px) 48px;
+}
+
+.dc-page .board-search input,
+.dc-page .board-search button {
+  min-height: 28px;
+  border-radius: 0;
+}
+
+.dc-page .board-search button {
+  background: #33458f;
+}
+
+.gallery-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid #bfc7dd;
+  border-top: 2px solid #33458f;
+  background: #fff;
+  padding: 10px 12px;
+}
+
+.gallery-banner h2 {
+  margin: 2px 0 4px;
+  color: #10172d;
+  font-size: 20px;
+}
+
+.gallery-banner p {
+  margin: 0;
+  color: #526070;
+  font-size: 12px;
+}
+
+.live-best-strip {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  border-bottom: 1px solid #d9dce7;
+  padding-bottom: 8px;
+}
+
+.best-card {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+}
+
+.best-thumb,
+.forum-thumb {
+  display: inline-grid;
+  place-items: center;
+  overflow: hidden;
+  background: #566391;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 900;
+}
+
+.best-thumb {
+  height: 76px;
+  border: 1px solid #c5c9d6;
+}
+
+.best-card strong {
+  overflow: hidden;
+  color: #111827;
+  font-size: 12px;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.thumb-0 {
+  background: #596b3f;
+}
+
+.thumb-1 {
+  background: #252b35;
+}
+
+.thumb-2 {
+  background: #526f9d;
+}
+
+.thumb-3 {
+  background: #8b704a;
+}
+
+.thumb-4 {
+  background: #3f6e6a;
+}
+
+.thumb-5 {
+  background: #6f4f79;
+}
+
+.dc-page .community-layout,
+.dc-page .board-page-layout {
+  grid-template-columns: minmax(0, 1fr) 220px;
+  gap: 14px;
+}
+
+.dc-page .community-main {
+  grid-column: 1;
+  grid-row: 1;
+  border: 0;
+  background: #fff;
+}
+
+.dc-page .community-right {
+  grid-column: 2;
+  grid-row: 1 / span 3;
+}
+
+.dc-page .community-left {
+  display: grid;
+  grid-column: 1;
+  grid-row: 2;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.dc-page .forum-box {
+  border-color: #d8d8d8;
+  border-radius: 0;
+  background: #fff;
+  padding: 10px;
+}
+
+.dc-page .forum-box h2,
+.dc-page .forum-board-head h2 {
+  color: #111827;
+  font-size: 14px;
+}
+
+.dc-page .forum-board-head {
+  min-height: 38px;
+  border-top: 2px solid #33458f;
+  border-bottom: 1px solid #c6ccdc;
+  padding: 8px 0;
+}
+
+.dc-page .forum-stats {
+  color: #27346e;
+  font-size: 12px;
+}
+
+.dc-page .forum-stats button {
+  min-height: 25px;
+  border-radius: 0;
+  background: #33458f;
+  padding: 3px 9px;
+}
+
+.dc-page .forum-table {
+  border-bottom: 1px solid #33458f;
+}
+
+.dc-page .forum-table-head,
+.dc-page .forum-row {
+  grid-template-columns: 42px 70px minmax(210px, 1fr) 94px 46px 46px 52px;
+  gap: 8px;
+}
+
+.dc-page .forum-table-head {
+  min-height: 29px;
+  border-top: 0;
+  border-bottom: 1px solid #c6ccdc;
+  background: #f3f4f8;
+  padding: 0 8px;
+  color: #4d5571;
+  font-size: 11px;
+}
+
+.dc-page .forum-row {
+  min-height: 47px;
+  border-bottom: 1px solid #ececf0;
+  padding: 4px 8px;
+  font-size: 12px;
+}
+
+.dc-page .forum-thumb {
+  width: 62px;
+  height: 38px;
+  border: 1px solid #d5d8e2;
+}
+
+.dc-page .notice-thumb {
+  background: #33458f;
+  font-size: 11px;
+}
+
+.dc-page .notice-row {
+  min-height: 34px;
+  background: #fafbff;
+}
+
+.dc-page .forum-title-cell {
+  gap: 5px;
+}
+
+.dc-page .forum-title-cell strong {
+  font-weight: 800;
+}
+
+.dc-page .board-chip,
+.dc-page .notice-chip {
+  border-radius: 0;
+  padding: 2px 5px;
+  font-size: 11px;
+}
+
+.dc-page .comment-badge {
+  color: #f03737;
+}
+
+.dc-page .forum-author,
+.dc-page .forum-date,
+.dc-page .forum-views,
+.dc-page .forum-likes {
+  color: #636a7d;
+  font-size: 11px;
+}
+
+.dc-page .ranking-list {
+  gap: 6px;
+  margin-top: 8px;
+  padding-left: 18px;
+}
+
+.dc-page .ranking-list span {
+  font-size: 12px;
+}
+
+.quick-links {
+  display: grid;
+  gap: 5px;
+  margin-top: 8px;
+}
+
+.quick-links button {
+  min-height: 24px;
+  border: 0;
+  border-radius: 0;
+  background: #f1f2f6;
+  color: #1f2d5f;
+  padding: 4px 8px;
+  text-align: left;
+  font-size: 12px;
+}
+
+.gallery-link-board {
+  border-top: 2px solid #33458f;
+  border-bottom: 1px solid #33458f;
+  padding: 12px 0;
+}
+
+.gallery-link-board h2 {
+  margin: 0 0 10px;
+  color: #27346e;
+  font-size: 14px;
+}
+
+.gallery-link-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border: 1px solid #e0e0e0;
+  border-right: 0;
+}
+
+.gallery-link-column {
+  display: grid;
+  align-content: start;
+  gap: 5px;
+  min-height: 132px;
+  border-right: 1px solid #e0e0e0;
+  padding: 10px 12px;
+}
+
+.gallery-link-column strong {
+  color: #27346e;
+}
+
+.gallery-link-column span {
+  color: #4b4f5f;
+  font-size: 12px;
+}
+
 .admin-page {
   display: grid;
   grid-template-columns: 252px minmax(0, 1fr);
@@ -1036,6 +1497,52 @@ pre {
     padding: 18px 16px 40px;
   }
 
+  .dc-page {
+    padding: 0 14px 40px;
+  }
+
+  .masthead,
+  .dc-page .nav {
+    margin-right: -14px;
+    margin-left: -14px;
+  }
+
+  .masthead {
+    padding: 18px 14px 14px;
+  }
+
+  .masthead-inner {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .wordmark {
+    font-size: 20px;
+  }
+
+  .masthead-count {
+    justify-self: start;
+  }
+
+  .nav-inner {
+    flex-wrap: wrap;
+    padding: 0 8px;
+  }
+
+  .dc-page .nav a {
+    padding: 0 9px;
+  }
+
+  .nav-spacer {
+    display: none;
+  }
+
+  .recent-bar,
+  .gallery-page-header,
+  .dc-page .panel {
+    max-width: none;
+  }
+
   .brand {
     flex-basis: 100%;
   }
@@ -1076,8 +1583,17 @@ pre {
     flex-direction: column;
   }
 
+  .gallery-banner {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
   .gallery-counts {
     justify-content: flex-start;
+  }
+
+  .live-best-strip {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .community-board .community-layout,
@@ -1086,14 +1602,21 @@ pre {
   }
 
   .community-board .community-main {
+    grid-column: 1;
+    grid-row: auto;
     order: 1;
   }
 
   .community-board .community-left {
+    grid-column: 1;
+    grid-row: auto;
+    grid-template-columns: 1fr;
     order: 2;
   }
 
   .community-board .community-right {
+    grid-column: 1;
+    grid-row: auto;
     order: 3;
   }
 
@@ -1131,6 +1654,10 @@ pre {
     padding: 12px 14px;
   }
 
+  .forum-thumb {
+    width: 72px;
+  }
+
   .forum-no::before {
     content: "No. ";
   }
@@ -1160,6 +1687,10 @@ pre {
     min-width: 42px;
     color: #657386;
     font-weight: 800;
+  }
+
+  .gallery-link-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .header h1,

--- a/Frontend/web-post/src/entities/post/model.ts
+++ b/Frontend/web-post/src/entities/post/model.ts
@@ -7,9 +7,11 @@ export interface PostSummary {
   likeCount: number;
   commentCount: number;
   status: string;
+  createdAt?: string;
+  author?: { id: number; email?: string; nickname: string };
 }
 
 export interface PostDetail extends PostSummary {
   content: string;
-  author?: { id: number; email: string; nickname: string };
+  updatedAt?: string;
 }

--- a/Frontend/web-post/src/pages/boards/page.tsx
+++ b/Frontend/web-post/src/pages/boards/page.tsx
@@ -3,7 +3,7 @@ import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function BoardsPage() {
   return (
-    <PageShell title="Boards" description="게시판을 살펴보고 최신 게시글을 목록 중심으로 확인합니다.">
+    <PageShell title="Boards" description="번호, 제목, 글쓴이, 조회, 추천 중심의 게시판 목록입니다.">
       <BoardPostsPanel />
     </PageShell>
   );

--- a/Frontend/web-post/src/pages/home/page.tsx
+++ b/Frontend/web-post/src/pages/home/page.tsx
@@ -3,7 +3,7 @@ import { PageShell } from "../../widgets/app-shell/PageShell";
 
 export function HomePage() {
   return (
-    <PageShell title="Post Board" description="게시판별 최신 글과 서비스 상태를 한 화면에서 확인합니다.">
+    <PageShell title="Post Board" description="실시간 글 목록, 게시판 분류, 인기글을 빠르게 훑어봅니다.">
       <HomeSummary />
     </PageShell>
   );

--- a/Frontend/web-post/src/shared/lib/format.ts
+++ b/Frontend/web-post/src/shared/lib/format.ts
@@ -1,0 +1,28 @@
+export function formatBoardDate(value?: string): string {
+  if (!value) {
+    return "-";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value.slice(0, 10);
+  }
+  const now = new Date();
+  const sameDay =
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate();
+  if (sameDay) {
+    return date.toLocaleTimeString("ko-KR", { hour: "2-digit", minute: "2-digit", hour12: false });
+  }
+  return `${String(date.getMonth() + 1).padStart(2, "0")}.${String(date.getDate()).padStart(2, "0")}`;
+}
+
+export function compactNumber(value: number): string {
+  if (value >= 10000) {
+    return `${Math.floor(value / 1000) / 10}만`;
+  }
+  if (value >= 1000) {
+    return `${Math.floor(value / 100) / 10}k`;
+  }
+  return String(value);
+}

--- a/Frontend/web-post/src/widgets/app-shell/PageShell.tsx
+++ b/Frontend/web-post/src/widgets/app-shell/PageShell.tsx
@@ -7,31 +7,58 @@ interface Props extends PropsWithChildren {
   kicker?: string;
 }
 
-const links = [
-  ["/", "Home"],
-  ["/boards", "Boards"],
-  ["/post-detail", "Post Detail"],
-  ["/mypage", "My Page"],
-  ["/login", "Login"],
-  ["/signup", "Signup"],
-  ["/admin", "Admin"],
+const mainLinks = [
+  ["/", "실시간 베스트"],
+  ["/boards", "갤러리"],
+  ["/post-detail", "게시글"],
+  ["/mypage", "마이페이지"],
+  ["/admin", "관리자"],
+];
+
+const accountLinks = [
+  ["/login", "로그인"],
+  ["/signup", "회원가입"],
 ];
 
 export function PageShell({ title, description, kicker = "Project-Bible Post", children }: Props) {
   return (
-    <main className="page">
-      <nav className="nav" aria-label="Post navigation">
-        <div className="brand">
-          <span className="brand-mark">PB</span>
-          <span>Post Board</span>
-        </div>
-        {links.map(([to, label]) => (
-          <NavLink key={to} to={to} className={({ isActive }) => (isActive ? "active" : undefined)}>
-            {label}
+    <main className="page dc-page">
+      <header className="masthead">
+        <div className="masthead-inner">
+          <NavLink to="/" className="wordmark" aria-label="Project Bible home">
+            Connecting Code
           </NavLink>
-        ))}
+          <form className="global-search" onSubmit={(event) => event.preventDefault()}>
+            <input aria-label="통합검색" placeholder="갤러리 & 통합검색" />
+            <button type="submit">검색</button>
+          </form>
+          <div className="masthead-count">
+            총 게시글 수 <strong>Project-Bible</strong>
+          </div>
+        </div>
+      </header>
+      <nav className="nav" aria-label="Post navigation">
+        <div className="nav-inner">
+          {mainLinks.map(([to, label]) => (
+            <NavLink key={to} to={to} className={({ isActive }) => (isActive ? "active" : undefined)}>
+              {label}
+            </NavLink>
+          ))}
+          <span className="nav-spacer" />
+          {accountLinks.map(([to, label]) => (
+            <NavLink key={to} to={to} className={({ isActive }) => (isActive ? "active" : undefined)}>
+              {label}
+            </NavLink>
+          ))}
+        </div>
       </nav>
-      <header className="header">
+      <div className="recent-bar">
+        <button type="button" className="recent-button">최근 방문 갤러리</button>
+        <span>post</span>
+        <span>free</span>
+        <span>qna</span>
+      </div>
+      <header className="header gallery-page-header">
         <div className="eyebrow">{kicker}</div>
         <h1>{title}</h1>
         <p>{description}</p>

--- a/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
+++ b/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
@@ -14,6 +14,17 @@ export function BoardPostsPanel() {
 
   return (
     <div className="community-board">
+      <section className="gallery-headline">
+        <div>
+          <span className="gallery-label">post gallery</span>
+          <h2>post 갤러리</h2>
+          <p>글번호, 제목, 글쓴이, 조회, 추천을 빠르게 훑는 갤러리형 게시판입니다.</p>
+        </div>
+        <div className="gallery-counts">
+          <span>전체글 <strong>{posts.data?.meta?.totalCount ?? 0}</strong></span>
+          <span>게시판 <strong>{boards.data?.length ?? 0}</strong></span>
+        </div>
+      </section>
       <div className="community-toolbar">
         <div className="board-tabs" aria-label="게시글 정렬">
           <button type="button" className="active">전체</button>

--- a/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
+++ b/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
@@ -14,29 +14,30 @@ export function BoardPostsPanel() {
 
   return (
     <div className="community-board">
-      <section className="gallery-headline">
-        <div>
-          <span className="gallery-label">post gallery</span>
-          <h2>post 갤러리</h2>
-          <p>글번호, 제목, 글쓴이, 조회, 추천을 빠르게 훑는 갤러리형 게시판입니다.</p>
-        </div>
-        <div className="gallery-counts">
-          <span>전체글 <strong>{posts.data?.meta?.totalCount ?? 0}</strong></span>
-          <span>게시판 <strong>{boards.data?.length ?? 0}</strong></span>
-        </div>
-      </section>
       <div className="community-toolbar">
         <div className="board-tabs" aria-label="게시글 정렬">
-          <button type="button" className="active">전체</button>
+          <button type="button" className="active">전체글</button>
           <button type="button">개념글</button>
-          <button type="button">댓글많은글</button>
-          <button type="button">조회많은글</button>
+          <button type="button">실시간</button>
+          <button type="button">조회순</button>
         </div>
         <div className="board-search">
           <input placeholder="검색어 입력" />
           <button type="button">검색</button>
         </div>
       </div>
+
+      <section className="gallery-banner">
+        <div>
+          <span className="gallery-label">post gallery</span>
+          <h2>post 갤러리</h2>
+          <p>번호, 이미지, 제목, 글쓴이, 조회, 추천을 한 줄에서 확인하는 게시판입니다.</p>
+        </div>
+        <div className="gallery-counts">
+          <span>전체글 <strong>{posts.data?.meta?.totalCount ?? 0}</strong></span>
+          <span>갤러리 <strong>{boards.data?.length ?? 0}</strong></span>
+        </div>
+      </section>
 
       <div className="community-layout board-page-layout">
         <aside className="community-left">
@@ -64,7 +65,7 @@ export function BoardPostsPanel() {
           <div className="forum-board-head">
             <div>
               <span className="eyebrow">All posts</span>
-              <h2>전체 게시글</h2>
+              <h2>전체글</h2>
             </div>
             <div className="forum-stats">
               <span>{posts.data?.meta?.totalCount ?? 0} posts</span>
@@ -88,7 +89,7 @@ export function BoardPostsPanel() {
           </section>
 
           <section className="forum-box compact">
-            <h2>게시판 정보</h2>
+            <h2>갤러리 정보</h2>
             <div className="mini-stat">
               <span>전체글</span>
               <strong>{posts.data?.meta?.totalCount ?? 0}</strong>

--- a/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
+++ b/Frontend/web-post/src/widgets/board-posts-panel/BoardPostsPanel.tsx
@@ -2,77 +2,93 @@ import { useQuery } from "@tanstack/react-query";
 import { fetchBoards } from "../../entities/board/api";
 import { fetchPosts } from "../../entities/post/api";
 import { CreatePostForm } from "../../features/post-create/CreatePostForm";
+import { ForumPostTable } from "../forum-post-table/ForumPostTable";
 
 export function BoardPostsPanel() {
   const boards = useQuery({ queryKey: ["boards"], queryFn: fetchBoards });
-  const posts = useQuery({ queryKey: ["posts"], queryFn: () => fetchPosts({ page: 1, limit: 20, sort: "latest" }) });
+  const posts = useQuery({ queryKey: ["posts"], queryFn: () => fetchPosts({ page: 1, limit: 30, sort: "latest" }) });
   const postRows = posts.data?.data ?? [];
+  const hotPosts = [...postRows]
+    .sort((left, right) => right.likeCount + right.commentCount - (left.likeCount + left.commentCount))
+    .slice(0, 6);
 
   return (
-    <div className="board-layout wide">
-      <aside className="board-rail">
-        <div className="section-heading">
-          <span className="eyebrow">Channel</span>
-          <h2>게시판 목록</h2>
+    <div className="community-board">
+      <div className="community-toolbar">
+        <div className="board-tabs" aria-label="게시글 정렬">
+          <button type="button" className="active">전체</button>
+          <button type="button">개념글</button>
+          <button type="button">댓글많은글</button>
+          <button type="button">조회많은글</button>
         </div>
-        <div className="board-list">
-          {boards.isLoading && <p className="muted">게시판을 불러오는 중입니다.</p>}
-          {boards.error && <p className="error">게시판을 불러오지 못했습니다.</p>}
-          {(boards.data ?? []).map((board) => (
-            <article className="board-item" key={board.id}>
-              <div>
-                <strong>{board.name}</strong>
-                <p>{board.description}</p>
-              </div>
-              <span className="pill">{board.status}</span>
-            </article>
-          ))}
+        <div className="board-search">
+          <input placeholder="검색어 입력" />
+          <button type="button">검색</button>
         </div>
+      </div>
 
-        <section className="compose-panel">
-          <div className="section-heading">
-            <span className="eyebrow">Compose</span>
-            <h2>글 작성</h2>
+      <div className="community-layout board-page-layout">
+        <aside className="community-left">
+          <section className="forum-box">
+            <h2>갤러리</h2>
+            <div className="category-list">
+              {boards.isLoading && <p className="muted">게시판을 불러오는 중입니다.</p>}
+              {boards.error && <p className="error">게시판을 불러오지 못했습니다.</p>}
+              {(boards.data ?? []).map((board) => (
+                <button type="button" key={board.id}>
+                  <span>{board.name}</span>
+                  <small>{board.description}</small>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="forum-box write-box">
+            <h2>글쓰기</h2>
+            <CreatePostForm />
+          </section>
+        </aside>
+
+        <section className="community-main">
+          <div className="forum-board-head">
+            <div>
+              <span className="eyebrow">All posts</span>
+              <h2>전체 게시글</h2>
+            </div>
+            <div className="forum-stats">
+              <span>{posts.data?.meta?.totalCount ?? 0} posts</span>
+              <button type="button">글쓰기</button>
+            </div>
           </div>
-          <CreatePostForm />
+          <ForumPostTable posts={postRows} loading={posts.isLoading} error={Boolean(posts.error)} />
         </section>
-      </aside>
 
-      <section className="post-feed">
-        <div className="section-heading split">
-          <div>
-            <span className="eyebrow">Latest</span>
-            <h2>전체 게시글</h2>
-          </div>
-          <span className="pill">{posts.data?.meta?.totalCount ?? 0} posts</span>
-        </div>
-        <div className="board-table">
-          <div className="board-table-head">
-            <span>게시글</span>
-            <span>반응</span>
-            <span>상태</span>
-          </div>
-          {posts.isLoading && <p className="empty-state">게시글을 불러오는 중입니다.</p>}
-          {posts.error && <p className="error">게시글을 불러오지 못했습니다.</p>}
-          {postRows.map((post) => (
-            <article className="board-table-row" key={post.id}>
-              <div className="post-main">
-                <span className="board-chip">{post.boardName ?? `board ${post.boardId}`}</span>
-                <strong>
-                  #{post.id} {post.title}
-                </strong>
-              </div>
-              <div className="post-meta">
-                <span>{post.viewCount} views</span>
-                <span>{post.likeCount} likes</span>
-                <span>{post.commentCount} comments</span>
-              </div>
-              <span className="pill">{post.status}</span>
-            </article>
-          ))}
-          {postRows.length === 0 && !posts.isLoading && <p className="empty-state">아직 표시할 게시글이 없습니다.</p>}
-        </div>
-      </section>
+        <aside className="community-right">
+          <section className="forum-box">
+            <h2>개념글</h2>
+            <ol className="ranking-list">
+              {hotPosts.map((post) => (
+                <li key={post.id}>
+                  <span>{post.title}</span>
+                  <small>{post.likeCount} 추천</small>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="forum-box compact">
+            <h2>게시판 정보</h2>
+            <div className="mini-stat">
+              <span>전체글</span>
+              <strong>{posts.data?.meta?.totalCount ?? 0}</strong>
+            </div>
+            <div className="mini-stat">
+              <span>게시판</span>
+              <strong>{boards.data?.length ?? 0}</strong>
+            </div>
+          </section>
+        </aside>
+      </div>
     </div>
   );
 }

--- a/Frontend/web-post/src/widgets/forum-post-table/ForumPostTable.tsx
+++ b/Frontend/web-post/src/widgets/forum-post-table/ForumPostTable.tsx
@@ -13,37 +13,40 @@ export function ForumPostTable({ posts, loading = false, error = false, emptyTex
     <div className="forum-table">
       <div className="forum-table-head">
         <span>번호</span>
+        <span>이미지</span>
         <span>제목</span>
         <span>글쓴이</span>
-        <span>작성일</span>
         <span>조회</span>
         <span>추천</span>
+        <span>날짜</span>
       </div>
       <article className="forum-row notice-row">
         <span className="forum-no">공지</span>
+        <span className="forum-thumb notice-thumb">공지</span>
         <div className="forum-title-cell">
           <span className="notice-chip">공지</span>
           <strong>post 갤러리 이용 안내</strong>
         </div>
         <span className="forum-author" data-label="글쓴이">운영자</span>
-        <span className="forum-date" data-label="작성일">상시</span>
         <span className="forum-views" data-label="조회">-</span>
         <span className="forum-likes" data-label="추천">-</span>
+        <span className="forum-date" data-label="날짜">상시</span>
       </article>
       {loading && <p className="empty-state">게시글을 불러오는 중입니다.</p>}
       {error && <p className="error empty-state">게시글을 불러오지 못했습니다.</p>}
       {posts.map((post) => (
         <article className="forum-row" key={post.id}>
           <span className="forum-no">{post.id}</span>
+          <span className={`forum-thumb thumb-${post.id % 6}`}>{post.boardName?.slice(0, 2) ?? "PB"}</span>
           <div className="forum-title-cell">
             <span className="board-chip">{post.boardName ?? `board ${post.boardId}`}</span>
             <strong>{post.title}</strong>
             {post.commentCount > 0 && <span className="comment-badge">[{post.commentCount}]</span>}
           </div>
           <span className="forum-author" data-label="글쓴이">{post.author?.nickname ?? "익명"}</span>
-          <span className="forum-date" data-label="작성일">{formatBoardDate(post.createdAt)}</span>
           <span className="forum-views" data-label="조회">{compactNumber(post.viewCount)}</span>
           <span className="forum-likes" data-label="추천">{compactNumber(post.likeCount)}</span>
+          <span className="forum-date" data-label="날짜">{formatBoardDate(post.createdAt)}</span>
         </article>
       ))}
       {posts.length === 0 && !loading && !error && <p className="empty-state">{emptyText}</p>}

--- a/Frontend/web-post/src/widgets/forum-post-table/ForumPostTable.tsx
+++ b/Frontend/web-post/src/widgets/forum-post-table/ForumPostTable.tsx
@@ -19,6 +19,17 @@ export function ForumPostTable({ posts, loading = false, error = false, emptyTex
         <span>조회</span>
         <span>추천</span>
       </div>
+      <article className="forum-row notice-row">
+        <span className="forum-no">공지</span>
+        <div className="forum-title-cell">
+          <span className="notice-chip">공지</span>
+          <strong>post 갤러리 이용 안내</strong>
+        </div>
+        <span className="forum-author" data-label="글쓴이">운영자</span>
+        <span className="forum-date" data-label="작성일">상시</span>
+        <span className="forum-views" data-label="조회">-</span>
+        <span className="forum-likes" data-label="추천">-</span>
+      </article>
       {loading && <p className="empty-state">게시글을 불러오는 중입니다.</p>}
       {error && <p className="error empty-state">게시글을 불러오지 못했습니다.</p>}
       {posts.map((post) => (

--- a/Frontend/web-post/src/widgets/forum-post-table/ForumPostTable.tsx
+++ b/Frontend/web-post/src/widgets/forum-post-table/ForumPostTable.tsx
@@ -1,0 +1,41 @@
+import type { PostSummary } from "../../entities/post/model";
+import { compactNumber, formatBoardDate } from "../../shared/lib/format";
+
+interface Props {
+  posts: PostSummary[];
+  loading?: boolean;
+  error?: boolean;
+  emptyText?: string;
+}
+
+export function ForumPostTable({ posts, loading = false, error = false, emptyText = "표시할 게시글이 없습니다." }: Props) {
+  return (
+    <div className="forum-table">
+      <div className="forum-table-head">
+        <span>번호</span>
+        <span>제목</span>
+        <span>글쓴이</span>
+        <span>작성일</span>
+        <span>조회</span>
+        <span>추천</span>
+      </div>
+      {loading && <p className="empty-state">게시글을 불러오는 중입니다.</p>}
+      {error && <p className="error empty-state">게시글을 불러오지 못했습니다.</p>}
+      {posts.map((post) => (
+        <article className="forum-row" key={post.id}>
+          <span className="forum-no">{post.id}</span>
+          <div className="forum-title-cell">
+            <span className="board-chip">{post.boardName ?? `board ${post.boardId}`}</span>
+            <strong>{post.title}</strong>
+            {post.commentCount > 0 && <span className="comment-badge">[{post.commentCount}]</span>}
+          </div>
+          <span className="forum-author" data-label="글쓴이">{post.author?.nickname ?? "익명"}</span>
+          <span className="forum-date" data-label="작성일">{formatBoardDate(post.createdAt)}</span>
+          <span className="forum-views" data-label="조회">{compactNumber(post.viewCount)}</span>
+          <span className="forum-likes" data-label="추천">{compactNumber(post.likeCount)}</span>
+        </article>
+      ))}
+      {posts.length === 0 && !loading && !error && <p className="empty-state">{emptyText}</p>}
+    </div>
+  );
+}

--- a/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
+++ b/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
@@ -1,47 +1,57 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchBoards } from "../../entities/board/api";
 import { fetchPosts } from "../../entities/post/api";
-import { fetchHealth } from "../../entities/session/api";
-import { env } from "../../shared/config/env";
 import { ForumPostTable } from "../forum-post-table/ForumPostTable";
 
+const fallbackTopics = [
+  "Spring Boot 게시판 인증 흐름 정리",
+  "React Query 캐시 무효화 패턴",
+  "관리자 댓글 모더레이션 화면 설계",
+  "PostgreSQL 시드 데이터 확인",
+];
+
+const footerSections = [
+  ["개념글", ["게임", "연예/방송", "스포츠", "여행/음식/생물", "취미/생활"]],
+  ["인기갤러리", ["post", "free", "qna", "notice-like", "admin"]],
+  ["주요 메뉴", ["글쓰기", "게시글", "마이페이지", "관리자"]],
+  ["갤러리 순회", ["Spring Boot", "React", "Database", "CLI", "문서"]],
+  ["디시미디어", ["프로젝트 로그", "릴리즈 노트", "테스트 결과", "운영 메모"]],
+] satisfies Array<[string, string[]]>;
+
 export function HomeSummary() {
-  const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
   const boards = useQuery({ queryKey: ["boards", "home"], queryFn: fetchBoards });
   const posts = useQuery({ queryKey: ["posts", "home"], queryFn: () => fetchPosts({ page: 1, limit: 15 }) });
-  const healthLabel = health.isLoading ? "Checking" : health.data?.status ?? "Unavailable";
   const recentPosts = posts.data?.data ?? [];
   const hotPosts = [...recentPosts].sort((left, right) => {
     const leftScore = left.likeCount * 3 + left.commentCount * 2 + left.viewCount;
     const rightScore = right.likeCount * 3 + right.commentCount * 2 + right.viewCount;
     return rightScore - leftScore;
   }).slice(0, 5);
+  const featured = [...hotPosts.map((post) => post.title), ...fallbackTopics].slice(0, 4);
 
   return (
     <div className="community-board">
-      <section className="gallery-headline">
-        <div>
-          <span className="gallery-label">post gallery</span>
-          <h2>post 갤러리</h2>
-          <p>실시간 글 목록과 인기글을 한 화면에서 확인합니다.</p>
-        </div>
-        <div className="gallery-counts">
-          <span>전체글 <strong>{posts.data?.meta?.totalCount ?? 0}</strong></span>
-          <span>댓글 <strong>{recentPosts.reduce((sum, post) => sum + post.commentCount, 0)}</strong></span>
-        </div>
-      </section>
       <div className="community-toolbar">
         <div className="board-tabs" aria-label="게시판 분류">
-          <button type="button" className="active">전체</button>
-          <button type="button">인기</button>
-          <button type="button">공지</button>
-          <button type="button">질문</button>
+          <button type="button" className="active">실시간 베스트</button>
+          <button type="button">실베라이트</button>
+          <button type="button">개념글</button>
+          <button type="button">랭킹</button>
         </div>
         <div className="board-search">
           <input placeholder="제목, 내용, 글쓴이 검색" />
           <button type="button">검색</button>
         </div>
       </div>
+
+      <section className="live-best-strip" aria-label="실시간 베스트">
+        {featured.map((title, index) => (
+          <article className="best-card" key={`${title}-${index}`}>
+            <div className={`best-thumb thumb-${index % 6}`}>{index + 1}</div>
+            <strong>{title}</strong>
+          </article>
+        ))}
+      </section>
 
       <div className="community-layout">
         <aside className="community-left">
@@ -58,10 +68,13 @@ export function HomeSummary() {
           </section>
 
           <section className="forum-box compact">
-            <h2>서비스</h2>
-            <p className="api-line">{env.apiBaseUrl}</p>
-            <span className={health.data?.status === "UP" ? "pill success-pill" : "pill"}>{healthLabel}</span>
-            {health.data?.service && <small className="api-line">{health.data.service}</small>}
+            <h2>최근 방문 갤러리</h2>
+            <div className="quick-links">
+              {(boards.data ?? []).slice(0, 4).map((board) => (
+                <button type="button" key={board.id}>{board.name}</button>
+              ))}
+              {(boards.data ?? []).length === 0 && <span className="muted">방문 기록이 없습니다.</span>}
+            </div>
           </section>
         </aside>
 
@@ -81,7 +94,7 @@ export function HomeSummary() {
 
         <aside className="community-right">
           <section className="forum-box">
-            <h2>실시간 인기글</h2>
+            <h2>실북갤</h2>
             <ol className="ranking-list">
               {hotPosts.map((post) => (
                 <li key={post.id}>
@@ -93,7 +106,7 @@ export function HomeSummary() {
           </section>
 
           <section className="forum-box compact">
-            <h2>오늘의 요약</h2>
+            <h2>HOT 흥한글</h2>
             <div className="mini-stat">
               <span>게시글</span>
               <strong>{posts.data?.meta?.totalCount ?? 0}</strong>
@@ -105,6 +118,20 @@ export function HomeSummary() {
           </section>
         </aside>
       </div>
+
+      <section className="gallery-link-board">
+        <h2>갤러리</h2>
+        <div className="gallery-link-grid">
+          {footerSections.map(([title, items]) => (
+            <div className="gallery-link-column" key={title}>
+              <strong>{title}</strong>
+              {items.map((item) => (
+                <span key={item}>{item}</span>
+              ))}
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
+++ b/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
@@ -19,6 +19,17 @@ export function HomeSummary() {
 
   return (
     <div className="community-board">
+      <section className="gallery-headline">
+        <div>
+          <span className="gallery-label">post gallery</span>
+          <h2>post 갤러리</h2>
+          <p>실시간 글 목록과 인기글을 한 화면에서 확인합니다.</p>
+        </div>
+        <div className="gallery-counts">
+          <span>전체글 <strong>{posts.data?.meta?.totalCount ?? 0}</strong></span>
+          <span>댓글 <strong>{recentPosts.reduce((sum, post) => sum + post.commentCount, 0)}</strong></span>
+        </div>
+      </section>
       <div className="community-toolbar">
         <div className="board-tabs" aria-label="게시판 분류">
           <button type="button" className="active">전체</button>

--- a/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
+++ b/Frontend/web-post/src/widgets/home-summary/HomeSummary.tsx
@@ -3,86 +3,96 @@ import { fetchBoards } from "../../entities/board/api";
 import { fetchPosts } from "../../entities/post/api";
 import { fetchHealth } from "../../entities/session/api";
 import { env } from "../../shared/config/env";
+import { ForumPostTable } from "../forum-post-table/ForumPostTable";
 
 export function HomeSummary() {
   const health = useQuery({ queryKey: ["health"], queryFn: fetchHealth });
   const boards = useQuery({ queryKey: ["boards", "home"], queryFn: fetchBoards });
-  const posts = useQuery({ queryKey: ["posts", "home"], queryFn: () => fetchPosts({ page: 1, limit: 5 }) });
-  const healthLabel = health.isLoading ? "Checking" : health.data ? `${health.data.status} / ${health.data.service}` : "Unavailable";
+  const posts = useQuery({ queryKey: ["posts", "home"], queryFn: () => fetchPosts({ page: 1, limit: 15 }) });
+  const healthLabel = health.isLoading ? "Checking" : health.data?.status ?? "Unavailable";
   const recentPosts = posts.data?.data ?? [];
+  const hotPosts = [...recentPosts].sort((left, right) => {
+    const leftScore = left.likeCount * 3 + left.commentCount * 2 + left.viewCount;
+    const rightScore = right.likeCount * 3 + right.commentCount * 2 + right.viewCount;
+    return rightScore - leftScore;
+  }).slice(0, 5);
 
   return (
-    <div className="home-board">
-      <div className="status-strip">
-        <div>
-          <span className="eyebrow">API Endpoint</span>
-          <strong>{env.apiBaseUrl}</strong>
+    <div className="community-board">
+      <div className="community-toolbar">
+        <div className="board-tabs" aria-label="게시판 분류">
+          <button type="button" className="active">전체</button>
+          <button type="button">인기</button>
+          <button type="button">공지</button>
+          <button type="button">질문</button>
         </div>
-        <span className={health.data?.status === "UP" ? "pill success-pill" : "pill"}>{healthLabel}</span>
-      </div>
-
-      <div className="metric-grid">
-        <div className="metric-card">
-          <span>Boards</span>
-          <strong>{boards.data?.length ?? 0}</strong>
-          <small>active board groups</small>
-        </div>
-        <div className="metric-card">
-          <span>Posts</span>
-          <strong>{posts.data?.meta?.totalCount ?? 0}</strong>
-          <small>total discussion threads</small>
-        </div>
-        <div className="metric-card accent">
-          <span>Latest</span>
-          <strong>{recentPosts[0]?.title ?? "No posts"}</strong>
-          <small>{recentPosts[0]?.boardName ?? `board ${recentPosts[0]?.boardId ?? "-"}`}</small>
+        <div className="board-search">
+          <input placeholder="제목, 내용, 글쓴이 검색" />
+          <button type="button">검색</button>
         </div>
       </div>
 
-      <div className="board-layout">
-        <section className="board-rail">
-          <div className="section-heading">
-            <span className="eyebrow">Boards</span>
+      <div className="community-layout">
+        <aside className="community-left">
+          <section className="forum-box">
             <h2>게시판</h2>
+            <div className="category-list">
+              {(boards.data ?? []).map((board) => (
+                <button type="button" key={board.id}>
+                  <span>{board.name}</span>
+                  <small>{board.status}</small>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section className="forum-box compact">
+            <h2>서비스</h2>
+            <p className="api-line">{env.apiBaseUrl}</p>
+            <span className={health.data?.status === "UP" ? "pill success-pill" : "pill"}>{healthLabel}</span>
+            {health.data?.service && <small className="api-line">{health.data.service}</small>}
+          </section>
+        </aside>
+
+        <section className="community-main">
+          <div className="forum-board-head">
+            <div>
+              <span className="eyebrow">Post Board</span>
+              <h2>전체글</h2>
+            </div>
+            <div className="forum-stats">
+              <span>{boards.data?.length ?? 0} boards</span>
+              <span>{posts.data?.meta?.totalCount ?? 0} posts</span>
+            </div>
           </div>
-          <div className="board-list">
-            {(boards.data ?? []).map((board) => (
-              <article className="board-item" key={board.id}>
-                <div>
-                  <strong>{board.name}</strong>
-                  <p>{board.description}</p>
-                </div>
-                <span className="pill">{board.status}</span>
-              </article>
-            ))}
-          </div>
+          <ForumPostTable posts={recentPosts} loading={posts.isLoading} error={Boolean(posts.error)} />
         </section>
 
-        <section className="post-feed">
-          <div className="section-heading split">
-            <div>
-              <span className="eyebrow">Recent posts</span>
-              <h2>최신 글</h2>
+        <aside className="community-right">
+          <section className="forum-box">
+            <h2>실시간 인기글</h2>
+            <ol className="ranking-list">
+              {hotPosts.map((post) => (
+                <li key={post.id}>
+                  <span>{post.title}</span>
+                  <small>{post.likeCount} 추천</small>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="forum-box compact">
+            <h2>오늘의 요약</h2>
+            <div className="mini-stat">
+              <span>게시글</span>
+              <strong>{posts.data?.meta?.totalCount ?? 0}</strong>
             </div>
-            <span className="muted">{posts.data?.meta?.totalCount ?? 0} total</span>
-          </div>
-          <div className="post-list">
-            {recentPosts.map((post) => (
-              <article className="post-row" key={post.id}>
-                <div className="post-main">
-                  <span className="board-chip">{post.boardName ?? `board ${post.boardId}`}</span>
-                  <strong>{post.title}</strong>
-                </div>
-                <div className="post-meta">
-                  <span>{post.viewCount} views</span>
-                  <span>{post.likeCount} likes</span>
-                  <span>{post.commentCount} comments</span>
-                </div>
-              </article>
-            ))}
-            {recentPosts.length === 0 && <p className="empty-state">아직 표시할 게시글이 없습니다.</p>}
-          </div>
-        </section>
+            <div className="mini-stat">
+              <span>댓글</span>
+              <strong>{recentPosts.reduce((sum, post) => sum + post.commentCount, 0)}</strong>
+            </div>
+          </section>
+        </aside>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Rework `web-post` public board pages into a dense community-style board layout.
- Use API-provided `boardName`, `createdAt`, and `author.nickname` in post lists.
- Add reusable forum table and formatting helpers for compact board rows.

## Implemented
- Added `ForumPostTable` with columns for number, title, author, date, views, and recommendations.
- Added date and compact-number formatting helpers.
- Reworked Home and Boards into toolbar + category rail + central board list + ranking/info side panels.
- Updated post model fields for `createdAt`, `updatedAt`, and optional author nickname/email.
- Added responsive mobile row labels so the forum table remains readable on small screens.

## Validation
- `npm run build`
- `npm run test`
- `git diff --check`
- CSS scan for viewport-scaled font sizes, negative letter spacing, orb/gradient/bokeh terms
- Playwright screenshot smoke checks for desktop `/`, `/boards`
- Playwright screenshot smoke checks for mobile `/boards`

Closes #33